### PR TITLE
Fixed inconsistent packet counters in 4 examples

### DIFF
--- a/examples/aes_decrypt/aesdecrypt.c
+++ b/examples/aes_decrypt/aesdecrypt.c
@@ -139,7 +139,7 @@ static void
 do_stats_display(struct rte_mbuf* pkt) {
         const char clr[] = { 27, '[', '2', 'J', '\0' };
         const char topLeft[] = { 27, '[', '1', ';', '1', 'H', '\0' };
-        static int pkt_process = 0;
+        static uint64_t pkt_process = 0;
         struct ipv4_hdr* ip;
 
         pkt_process += print_delay;
@@ -151,7 +151,7 @@ do_stats_display(struct rte_mbuf* pkt) {
         printf("-----\n");
         printf("Port : %d\n", pkt->port);
         printf("Size : %d\n", pkt->pkt_len);
-        printf("N°   : %d\n", pkt_process);
+        printf("N°   : %"PRIu64"\n", pkt_process);
         printf("\n\n");
 
         ip = onvm_pkt_ipv4_hdr(pkt);

--- a/examples/aes_encrypt/aesencrypt.c
+++ b/examples/aes_encrypt/aesencrypt.c
@@ -139,7 +139,7 @@ static void
 do_stats_display(struct rte_mbuf* pkt) {
         const char clr[] = { 27, '[', '2', 'J', '\0' };
         const char topLeft[] = { 27, '[', '1', ';', '1', 'H', '\0' };
-        static int pkt_process = 0;
+        static uint64_t pkt_process = 0;
         struct ipv4_hdr* ip;
 
         pkt_process += print_delay;
@@ -151,7 +151,7 @@ do_stats_display(struct rte_mbuf* pkt) {
         printf("-----\n");
         printf("Port : %d\n", pkt->port);
         printf("Size : %d\n", pkt->pkt_len);
-        printf("N°   : %d\n", pkt_process);
+        printf("N°   : %"PRIu64"\n", pkt_process);
         printf("\n\n");
 
         ip = onvm_pkt_ipv4_hdr(pkt);

--- a/examples/basic_monitor/monitor.c
+++ b/examples/basic_monitor/monitor.c
@@ -112,7 +112,7 @@ static void
 do_stats_display(struct rte_mbuf* pkt) {
         const char clr[] = { 27, '[', '2', 'J', '\0' };
         const char topLeft[] = { 27, '[', '1', ';', '1', 'H', '\0' };
-        static int pkt_process = 0;
+        static uint64_t pkt_process = 0;
         struct ipv4_hdr* ip;
 
         pkt_process += print_delay;
@@ -125,7 +125,7 @@ do_stats_display(struct rte_mbuf* pkt) {
         printf("Port : %d\n", pkt->port);
         printf("Size : %d\n", pkt->pkt_len);
         printf("Hash : %u\n", pkt->hash.rss);
-	printf("N°   : %d\n", pkt_process);
+	printf("N°   : %ld\n", pkt_process);
         printf("\n\n");
 
         ip = onvm_pkt_ipv4_hdr(pkt);

--- a/examples/basic_monitor/monitor.c
+++ b/examples/basic_monitor/monitor.c
@@ -125,7 +125,7 @@ do_stats_display(struct rte_mbuf* pkt) {
         printf("Port : %d\n", pkt->port);
         printf("Size : %d\n", pkt->pkt_len);
         printf("Hash : %u\n", pkt->hash.rss);
-	printf("N°   : %ld\n", pkt_process);
+	printf("N°   : %"PRIu64"\n", pkt_process);
         printf("\n\n");
 
         ip = onvm_pkt_ipv4_hdr(pkt);

--- a/examples/bridge/bridge.c
+++ b/examples/bridge/bridge.c
@@ -125,7 +125,7 @@ do_stats_display(struct rte_mbuf* pkt) {
         printf("Port : %d\n", pkt->port);
         printf("Size : %d\n", pkt->pkt_len);
         printf("Type : %d\n", pkt->packet_type);
-        printf("Number of packet processed : %ld\n", pkt_process);
+        printf("Number of packet processed : %"PRIu64"\n", pkt_process);
 
         ip = onvm_pkt_ipv4_hdr(pkt);
         if(ip != NULL) {

--- a/examples/bridge/bridge.c
+++ b/examples/bridge/bridge.c
@@ -111,7 +111,7 @@ static void
 do_stats_display(struct rte_mbuf* pkt) {
         const char clr[] = { 27, '[', '2', 'J', '\0' };
         const char topLeft[] = { 27, '[', '1', ';', '1', 'H', '\0' };
-        static int pkt_process = 0;
+        static uint64_t pkt_process = 0;
 
         struct ipv4_hdr* ip;
 
@@ -125,7 +125,7 @@ do_stats_display(struct rte_mbuf* pkt) {
         printf("Port : %d\n", pkt->port);
         printf("Size : %d\n", pkt->pkt_len);
         printf("Type : %d\n", pkt->packet_type);
-        printf("Number of packet processed : %d\n", pkt_process);
+        printf("Number of packet processed : %ld\n", pkt_process);
 
         ip = onvm_pkt_ipv4_hdr(pkt);
         if(ip != NULL) {

--- a/examples/flow_table/flow_table.c
+++ b/examples/flow_table/flow_table.c
@@ -150,7 +150,7 @@ do_stats_display(struct rte_mbuf* pkt, int32_t tbl_index) {
 
         printf("FLOW TABLE NF\n");
         printf("-----\n");
-        printf("Total pkts   : %ld\n", total_pkts);
+        printf("Total pkts   : %"PRIu64"\n", total_pkts);
         printf("Total flows  : %d\n", total_flows);
         printf("Flow ID      : %d\n", tbl_index);
         printf("Flow pkts    : %"PRIu64"\n", flow_entry->packet_count);

--- a/examples/flow_table/flow_table.c
+++ b/examples/flow_table/flow_table.c
@@ -137,7 +137,7 @@ static void
 do_stats_display(struct rte_mbuf* pkt, int32_t tbl_index) {
         const char clr[] = { 27, '[', '2', 'J', '\0' };
         const char topLeft[] = { 27, '[', '1', ';', '1', 'H', '\0' };
-        static int total_pkts = 0;
+        static uint64_t total_pkts = 0;
         /* Fix unused variable warnings: */
         (void)pkt;
 
@@ -150,7 +150,7 @@ do_stats_display(struct rte_mbuf* pkt, int32_t tbl_index) {
 
         printf("FLOW TABLE NF\n");
         printf("-----\n");
-        printf("Total pkts   : %d\n", total_pkts);
+        printf("Total pkts   : %ld\n", total_pkts);
         printf("Total flows  : %d\n", total_flows);
         printf("Flow ID      : %d\n", tbl_index);
         printf("Flow pkts    : %"PRIu64"\n", flow_entry->packet_count);
@@ -182,7 +182,6 @@ flow_table_hit(struct rte_mbuf* pkt, struct onvm_pkt_meta* meta) {
 static int
 flow_table_miss(struct rte_mbuf* pkt, struct onvm_pkt_meta* meta) {
         int ret;
-
 
         /* Buffer new flows until we get response from SDN controller. */
         ret = rte_ring_enqueue(ring_to_sdn, pkt);

--- a/examples/simple_forward/forward.c
+++ b/examples/simple_forward/forward.c
@@ -138,7 +138,7 @@ do_stats_display(struct rte_mbuf* pkt) {
         printf("-----\n");
         printf("Port : %d\n", pkt->port);
         printf("Size : %d\n", pkt->pkt_len);
-        printf("N°   : %ld\n", pkt_process);
+        printf("N°   : %"PRIu64"\n", pkt_process);
         printf("\n\n");
 
         ip = onvm_pkt_ipv4_hdr(pkt);

--- a/examples/simple_forward/forward.c
+++ b/examples/simple_forward/forward.c
@@ -126,7 +126,7 @@ static void
 do_stats_display(struct rte_mbuf* pkt) {
         const char clr[] = { 27, '[', '2', 'J', '\0' };
         const char topLeft[] = { 27, '[', '1', ';', '1', 'H', '\0' };
-        static int pkt_process = 0;
+        static uint64_t pkt_process = 0;
         struct ipv4_hdr* ip;
 
         pkt_process += print_delay;
@@ -138,7 +138,7 @@ do_stats_display(struct rte_mbuf* pkt) {
         printf("-----\n");
         printf("Port : %d\n", pkt->port);
         printf("Size : %d\n", pkt->pkt_len);
-        printf("N°   : %d\n", pkt_process);
+        printf("N°   : %ld\n", pkt_process);
         printf("\n\n");
 
         ip = onvm_pkt_ipv4_hdr(pkt);

--- a/examples/test_flow_dir/test_flow_dir.c
+++ b/examples/test_flow_dir/test_flow_dir.c
@@ -126,7 +126,7 @@ static void
 do_stats_display(struct rte_mbuf* pkt) {
         const char clr[] = { 27, '[', '2', 'J', '\0' };
         const char topLeft[] = { 27, '[', '1', ';', '1', 'H', '\0' };
-        static int pkt_process = 0;
+        static uint64_t pkt_process = 0;
         struct ipv4_hdr* ip;
 
         pkt_process += print_delay;
@@ -138,7 +138,7 @@ do_stats_display(struct rte_mbuf* pkt) {
         printf("-----\n");
         printf("Port : %d\n", pkt->port);
         printf("Size : %d\n", pkt->pkt_len);
-        printf("N°   : %d\n", pkt_process);
+        printf("N°   : %"PRIu64"\n", pkt_process);
         printf("\n\n");
 
         ip = onvm_pkt_ipv4_hdr(pkt);


### PR DESCRIPTION
If you run an e.g., bridge NF and start injecting millions of pps for a long period of time, the int packet counters run out of memory. This patch overcomes this problem. You can probably follow similar approach to fix other examples.