### PR TITLE
Closes #15: ONVM installation issues - mount huge pages

### DIFF
--- a/docs/Install.md
+++ b/docs/Install.md
@@ -44,22 +44,27 @@ This guide helps you build and install openNetVM.
 3. Set up Environment
 --
 
-1. List DPDK supported architectures:
+1. Set environment variable ONVM_HOME to the path of the openNetVM source directory.
+    ```sh
+    echo export ONVM_HOME=$(pwd) >> ~/.bashrc
+    ```
+
+2. List DPDK supported architectures:
     ```sh
     ls dpdk/config/
     ```
 
-2. Set environment variable RTE_SDK to the path of the DPDK library.  Make sure that you are in the DPDK directory
+3. Set environment variable RTE_SDK to the path of the DPDK library.  Make sure that you are in the DPDK directory
     ```sh
     echo export RTE_SDK=$(pwd) >> ~/.bashrc
     ```
 
-3. Set environment variable RTE_TARGET to the target architecture of your system.  This is found in step 3.1
+4. Set environment variable RTE_TARGET to the target architecture of your system.  This is found in step 3.1
     ```sh
     echo export RTE_TARGET=x86_64-native-linuxapp-gcc  >> ~/.bashrc
     ```
 
-4. Set environment variable ONVM_NUM_HUGEPAGES and ONVM_NIC_PCI.
+5. Set environment variable ONVM_NUM_HUGEPAGES and ONVM_NIC_PCI.
 
     ONVM_NUM_HUGEPAGES is a variable specifies how many hugepages are reserved by the user, default value of this is 1024, which could be set using:
     ```sh
@@ -70,17 +75,17 @@ This guide helps you build and install openNetVM.
     ```sh
     export ONVM_NIC_PCI=" 07:00.0 07:00.1 "
     ```
-5. Source your shell rc file to set the environment variables:
+6. Source your shell rc file to set the environment variables:
     ```sh
     source ~/.bashrc
     ```
 
-6. Disable ASLR since it makes sharing memory with NFs harder:
+7. Disable ASLR since it makes sharing memory with NFs harder:
    ```sh
     sudo sh -c "echo 0 > /proc/sys/kernel/randomize_va_space"
     ```
 
-4. Configure and compile DPDK
+8. Configure and compile DPDK
 --
 
 1. Run the [install script](../scripts/install.sh) to compile DPDK and configure hugepages.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -107,7 +107,7 @@ if [ -z "$ONVM_SKIP_FSTAB" ]; then
 fi
 
 #Only mount hugepages if user wants to 
-if [ -z "ONVM_SKIP_HUGEPAGES" ]; then
+if [ -z "$ONVM_SKIP_HUGEPAGES" ]; then
 	echo "Mounting hugepages"
 	sleep 1
 	sudo mount -t hugetlbfs nodev /mnt/huge

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -99,8 +99,9 @@ if [ -z "$ONVM_SKIP_HUGEPAGES" ]; then
 	sudo mkdir -p /mnt/huge
 fi
 
+grep -m 1 "huge" /etc/fstab | cat
 # Only add to /etc/fstab if user wants it
-if [ -z "$ONVM_SKIP_FSTAB" ]; then
+if [ ${PIPESTATUS[0]} != 0 ] && [ -z "$ONVM_SKIP_FSTAB" ]; then
     echo "Adding huge fs to /etc/fstab"
     sleep 1
     sudo sh -c "echo \"huge /mnt/huge hugetlbfs defaults 0 0\" >> /etc/fstab"


### PR DESCRIPTION
Fixes bug where install script wouldn't mount the huge page file system. 
Also fixes bug where script would write to `/etc/fstab` multiple times. 

Additionally, updates the install documentation to mention the environment variable `ONVM_HOME`.
`ONVM_HOME` is a required variable, so that should be reflected in the doc.

**Summary:**
On a fresh install, ONVM's install script failed to mount huge fs because of a simple typo. Because bash looks for a `$` to find variables, the script was treating `ONVM_SKIP_HUGEPAGES` as a static string rather than a variable, and the check before mounting the huge fs always failed. The fix is to add `$`.

**Test Plan:**
Made changes to script and installed on a fresh cloudlab instance. The manager ran without crashing. I then rebooted the machine and ran `install.sh` again to see whether the code within the if statement causes problems. The manager ran as expected. 

(optional) **Reviewers:** @twood02 
