### PR TITLE
Remove inline modifier from pkt_enqueue_nf function

### DIFF
--- a/onvm/onvm_nflib/onvm_pkt_common.c
+++ b/onvm/onvm_nflib/onvm_pkt_common.c
@@ -177,7 +177,7 @@ onvm_pkt_flush_nf_queue(struct queue_mgr *tx_mgr, uint16_t nf_id) {
         nf_buf->count = 0;
 }
 
-inline void
+void
 onvm_pkt_enqueue_nf(struct queue_mgr *tx_mgr, uint16_t dst_service_id, struct rte_mbuf *pkt) {
         struct onvm_nf *nf;
         uint16_t dst_instance_id;

--- a/onvm/onvm_nflib/onvm_pkt_common.h
+++ b/onvm/onvm_nflib/onvm_pkt_common.h
@@ -104,7 +104,7 @@ onvm_pkt_flush_nf_queue(struct queue_mgr *tx_mgr, uint16_t nf_id);
  *          a pointer to the packet
  *
  */
-inline void
+void
 onvm_pkt_enqueue_nf(struct queue_mgr *tx_mgr, uint16_t dst_service_id, struct rte_mbuf *pkt);
 
 /*


### PR DESCRIPTION
Remove `inline` keyword from `onvm_pkt_enqueue_nf` prototype. 

**Summary:**
User experienced compiler error which is noted in this [issue](https://github.com/sdnfv/openNetVM/issues/22), most likely due to a newer version of `gcc`. The solution was to remove `inline` keyword from `onvm_pkt_enqueue_nf`, which we suspect the user's compiler interpreted as an error. `onvm_pkt_enqueue_nf` is part of the API, so it should not be treated as an inline function anyway.  

**Test Plan:**
Compiles as normal. Ran speed tester NF twice and recorded 38 Mpps and 42 Mpps (respectively).

**Reviewers:** @twood02 @nks5295 
