### PR TITLE
Update flow_table.c

### DIFF
--- a/examples/flow_table/flow_table.c
+++ b/examples/flow_table/flow_table.c
@@ -86,6 +86,16 @@ static uint32_t total_flows;
 /* Setup rings to hold buffered packets destined for SDN controller */
 static void
 setup_rings(void) {
+        /* Remove old ring buffers */
+        ring_to_sdn = rte_ring_lookup("ring_to_sdn");
+        ring_from_sdn = rte_ring_lookup("ring_from_sdn");
+        if (ring_to_sdn) {
+            rte_ring_free(ring_to_sdn);
+        }
+        if (ring_from_sdn) {
+            rte_ring_free(ring_from_sdn);
+        }
+
         ring_to_sdn = rte_ring_create("ring_to_sdn", SDN_RING_SIZE,
                         rte_socket_id(), RING_F_SP_ENQ | RING_F_SC_DEQ);
         ring_from_sdn = rte_ring_create("ring_from_sdn", SDN_RING_SIZE,


### PR DESCRIPTION
Remove old ring buffers on startup.

On startup,  the flow_table NF will try to connect SDN Controller. If it fails to connect, it exits and does not release the ring buffers it allocated. Then the flow_table NF cannot be started anymore, for it will find the ring buffers already exists and refuse to start.
It will be better if the flow_table NF can release the rings buffers before exiting. But covering all the abnormal branches is difficult, cleaning the buffers before NF startup is a simple way to solve this problem.

**Summary:** Remove old ring buffers on startup 

**Test Plan:** 1. Shutdown SDN controller; 
                        2. Start flow_table NF; it will fail and end. 
                        3. Start the SDN controller;
                        4. Start flow_table NF; it should connect to SDN controller successfully.

(optional) **Reviewers:** << @-mention people who should review these changes >>

(optional) **Subscribers:** << @-mention people who probably care about these changes >>
