### PR TITLE
Add ONVM Dockerfile and Update Docker Resources

### DIFF
--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -1,65 +1,44 @@
 Running openNetVM in Docker
 ==
 
-To run openNetVM NFs inside Docker containers, use the
-included [Docker Script][docker]. This script does the following:
+To run openNetVM NFs inside Docker containers, use the included [Docker Script][docker].  We provide a [Docker image on Docker Hub][onvm-docker] that is a copy of [Ubuntu 14.04][ubuntu] with a few dependencies installed.  This script does the following:
 
-  - Creates a Docker container with a custom name
+  - Creates a Docker container off of the [sdnfv/opennetvm Docker image][onvm-docker] with a custom name
   - Maps NIC devices from the host into the container
   - Maps the shared hugepage region into the container
   - Maps the openNetVM directory into the container
   - Maps any other directories you want into the container
-  - Configures the container to use all of the shared memory and data
-    structures
-  - Depending on the presence of a path or not, the container starts the NF
-    automatically in detached mode or the terminal is connected to it to
-    run the NF by hand
+  - Configures the container to use all of the shared memory and data structures
+  - Depending on the presence of a command to run, the container starts the NF automatically in detached mode or the terminal is connected to it to run the NF by hand
 
 Usage
 --
 
-To use the script, simply run it from the command line with the
-following options:
+To use the script, simply run it from the command line with the following options:
 
-    ```
-    sudo ./docker.sh -h HUGEPAGES -o ONVM -n NAME [-D DEVICES] [-d DIRECTORY] [-w WORKING DIRECTORY] [-c COMMAND]
-    ```
+```bash
+sudo ./docker.sh -h HUGEPAGES -o ONVM -n NAME [-D DEVICES] [-d DIRECTORY] [-c COMMAND]
+```
 
   - `HUGEPAGES - A path to where the hugepage filesystem is on the host`
   - `ONVM - A path to the openNetVM directory on the host filesystem`
   - `NAME - A name to give the container`
-  - `DEVICES - An optional comma deliniated list of NIC devices to map to the
-    container`
+  - `DEVICES - An optional comma deliniated list of NIC devices to map to the container`
   - `DIRECTORY - An optional additional directory to map inside the container.`
-  - `WORKINGDIRECTORY - An optional directory in the container to be the working
-     directory at start time. It allows a better control on the command to be run.`
-  - `COMMAND - An optional command to run in the container. For example,
-     the path to a go-docker script or to the executable of your NF.`
+  - `COMMAND - An optional command to run in the container. For example, the path to a go script or to the executable of your NF.`
 
-    ```
-    sudo ./docker.sh -h /mnt/huge -o /root/openNetVM -n Basic_Monitor_NF
--D /dev/uio0,/dev/uio1
+    ```bash
+    sudo ./docker.sh -h /mnt/huge -o /root/openNetVM -n Basic_Monitor_NF -D /dev/uio0,/dev/uio1
     ```
 
-  - This will start a container with two NIC devices mapped in, /dev/uio0
-and /dev/uio1, the hugepage directory at `/mnt/huge` mapped in, and the
-openNetVM source directory at `/root/openNetVM` mapped into the
-container with the name of Basic_Monitor_NF.
+  - This will start a container with two NIC devices mapped in, /dev/uio0 and /dev/uio1, the hugepage directory at `/mnt/huge` mapped in, and the openNetVM source directory at `/root/openNetVM` mapped into the container with the name of Basic_Monitor_NF.
 
-    ```
-    sudo ./docker.sh -h /mnt/huge -o /root/openNetVM -n Simple_Forward_NF
--D /dev/uio0 -w /openNetVM/examples/simple_forward -c "./go-docker.sh 5 1 1"
+    ```bash
+    sudo ./docker.sh -h /mnt/huge -o /root/openNetVM -n Speed_Tester_NF -D /dev/uio0 -c "./examples/speed_tester/go.sh 5 1 1"
     ```
 
-  - This will start a container with one NIC device mapped in, /dev/uio0
-, the hugepage directory at `/mnt/huge` mapped in, and the
-openNetVM source directory at `/root/openNetVM` mapped into the
-container with the name of Simple_Forward_NF. Also, the container will be
-started in detached mode (no connection to it). It will have the simple_forward
-subdirectory as its working directory, and it will run the go-docker script of
-the simple forward NF.
-Careful, the path needs to be correct inside the container (use absolute path,
- here the openNetVM directory is mapped in the /).
+  - This will start a container with one NIC device mapped in, /dev/uio0 , the hugepage directory at `/mnt/huge` mapped in, and the openNetVM source directory at `/root/openNetVM` mapped into the container with the name of Speed_Tester_NF. Also, the container will be started in detached mode (no connection to it) and it will run the go script of the simple forward NF.
+Careful, the path needs to be correct inside the container (use absolute path, here the openNetVM directory is mapped in the /).
 
 
 Running NFs Inside Containers
@@ -74,48 +53,47 @@ Some prerequisites are:
 
 Here is an example of starting a container and then running an NF inside of it:
 
-```
-root@nimbnode /root/openNetVM # ./scripts/docker.sh
+```bash
+root@nimbnode /root/openNetVM/scripts# ./docker.sh
+sudo ./docker.sh -h HUGEPAGES -o ONVM -n NAME [-D DEVICES] [-d DIRECTORY] [-c COMMAND]
 
-sudo ./docker.sh -h HUGEPAGES -o ONVM -n NAME [-D DEVICES] [-d DIRECTORY] [-w WORKINGDIRECTORY] [-c COMMAND]
+        e.g. sudo ./docker.sh -h /hugepages -o /root/openNetVM -n Basic_Monitor_NF -D /dev/uio0,/dev/uio1
+                This will create a container with two NIC devices, uio0 and uio1,
+                hugepages mapped from the host's /hugepage directory and openNetVM
+                mapped from /root/openNetVM and it will name it Basic_Monitor_NF
 
-    e.g. sudo ./docker.sh -h /hugepages -o /root/openNetVM -n Basic_Monitor_NF -D /dev/uio0,/dev/uio1
-    This will create a container with two NIC devices, uio0 and uio1,
-    hugepages mapped from the host's /hugepage directory and openNetVM
-    mapped from /root/openNetVM and it will name it Basic_Monitor_NF
-
-root@nimbnode /root/openNetVM # ./scripts/docker.sh -h /hugepages -o /home/neel/openNetVM -n ExampleNF -D /dev/uio0,/dev/uio1
-root@2f20c33f9d69:/# ls
-bin  boot  dev  etc  home  hugepages  lib  lib64  media  mnt  openNetVM  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
-root@2f20c33f9d69:/# cd openNetVM/
-root@2f20c33f9d69:/openNetVM# ls
-CPPLINT.cfg  LICENSE  Makefile  README.md  docs  dpdk  examples  onvm  scripts  style  tags
-root@2f20c33f9d69:/openNetVM# cd examples/
-root@2f20c33f9d69:/openNetVM/examples# ls
-Makefile  basic_monitor  bridge  flow_table  simple_forward  speed_tester  test_flow_dir
-root@2f20c33f9d69:/openNetVM/examples# cd basic_monitor/
-root@2f20c33f9d69:/openNetVM/examples/basic_monitor# ls
-Makefile  README.md  basic_monitor  build  go.sh  monitor.c
-root@2f20c33f9d69:/openNetVM/examples/basic_monitor# ./go.sh
+root@nimbnode /root/openNetVM/scripts# ./docker.sh -h /mnt/huge -o /root/openNetVM-dev -D /dev/uio0,/dev/uio1 -n basic_monitor
+root@899618eaa98c:/openNetVM# ls
+CPPLINT.cfg  LICENSE  Makefile  README.md  cscope.out  docs  dpdk examples  onvm  onvm_web  scripts  style  tags  tools
+root@899618eaa98c:/openNetVM# cd examples/
+root@899618eaa98c:/openNetVM/examples# ls
+Makefile  aes_decrypt  aes_encrypt  arp_response  basic_monitor  bridge flow_table  flow_tracker  load_balancer  ndpi_stats  nf_router simple_forward  speed_tester  test_flow_dir
+root@899618eaa98c:/openNetVM/examples# cd basic_monitor/
+root@899618eaa98c:/openNetVM/examples/basic_monitor# ls
+Makefile  README.md  build  go.sh  monitor.c
+root@899618eaa98c:/openNetVM/examples/basic_monitor# ./go.sh
 ./go.sh CPU-LIST SERVICE-ID [-p PRINT] [-n NF-ID]
 ./go.sh 3 0 --> core 3, Service ID 0
 ./go.sh 3,7,9 1 --> cores 3,7, and 9 with Service ID 1
-./go.sh -p 1000 -n 6 3,7,9 1 --> cores 3,7, and 9 with Service ID 1 and Print Rate of 1000 and instance ID 6
-root@2f20c33f9d69:/openNetVM/examples/basic_monitor# ./go.sh 3 1
+./go.sh -p 1000 -n 6 3,7,9 1 --> cores 3,7, and 9 with Service ID 1 and
+Print Rate of 1000 and instance ID 6
+root@899618eaa98c:/openNetVM/examples/basic_monitor# ./go.sh 3 1
 ...
 ```
 
-You can also use the optional command argument to run directly the NF inside of the container (and the optional working directory argument to have more control on the command context of execution), without connecting to it. Then, to stop gracefully the NF (so it has time to notify onvm manager), use the docker stop command before docker rm the container.
+You can also use the optional command argument to run directly the NF inside of the container, without connecting to it. Then, to stop gracefully the NF (so it has time to notify onvm manager), use the docker stop command before docker rm the container.
 The prerequisites are the same as in the case where you connect to the container.
 
-```
-root@nimbnode /root/openNetVM # ./scripts/docker.sh -h /hugepages -o /home/adam/openNetVM -n ExampleNF -D /dev/uio0,/dev/uio1 -w /openNetVM/examples/simple_forward/ -c "./go-docker.sh 5 1 1"
+```bash
+root@nimbnode /root/openNetVM# ./scripts/docker.sh -h /mnt/huge -o /root/openNetVM -n speed_tester_nf -D /dev/uio0,/dev/uio1 -c "./examples/speed_tester/go.sh 5 1 1"
 14daebeba1adea581c2998eead16ff7ce7fdc45394c0cc5d6489228aad939711
-root@nimbnode /root/openNetVM # sudo docker stop ExampleNF
-ExampleNF
-root@nimbnode /root/openNetVM # sudo docker rm ExampleNF
-ExampleNF
+root@nimbnode /root/openNetVM# sudo docker stop speed_tester_nf
+speed_tester_nf
+root@nimbnode /root/openNetVM# sudo docker rm speed_tester_nf
+speed_tester_nf
 ...
 ```
 
 [docker]: ../scripts/docker.sh
+[onvm-docker]: https://hub.docker.com/r/sdnfv/opennetvm/
+[ubuntu]: http://releases.ubuntu.com/14.04/

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 #                        openNetVM
 #                https://sdnfv.github.io
 #
@@ -36,64 +34,22 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-while getopts :d:c:D:h:o:n: OPTION ; do
-    case ${OPTION} in
-        d) DIR="${OPTARG}" ;;
-        c) CMD=${OPTARG} ;;
-        D) RAW_DEVICES=${OPTARG} ;;
-        h) HUGE=${OPTARG} ;;
-        o) ONVM=${OPTARG} ;;
-        n) NAME=${OPTARG} ;;
-    esac
-done
+FROM ubuntu:14.04
+MAINTAINER "Neel Shah" <neel@shah7.com>
+LABEL version="OpenNetVM v18.03"
+LABEL vendor="SDNFV @ UCR and GW"
+LABEL github="github.com/sdnfv/openNetVM"
 
-DEVICES=()
-MODE=""
+ENV ONVM_HOME=/openNetVM
+ENV RTE_TARGET=x86_64-native-linuxapp-gcc
+ENV RTE_SDK=$ONVM_HOME/dpdk
 
-if [[ "${NAME}" == "" ]] || [[ "${HUGE}" == "" ]] || [[ "${ONVM}" == "" ]] ; then
-    echo -e "sudo ./docker.sh -h HUGEPAGES -o ONVM -n NAME [-D DEVICES] [-d DIRECTORY] [-c COMMAND]\n"
-    echo -e "\te.g. sudo ./docker.sh -h /hugepages -o /root/openNetVM -n Basic_Monitor_NF -D /dev/uio0,/dev/uio1"
-    echo -e "\t\tThis will create a container with two NIC devices, uio0 and uio1,"
-    echo -e "\t\thugepages mapped from the host's /hugepage directory and openNetVM"
-    echo -e "\t\tmapped from /root/openNetVM and it will name it Basic_Monitor_NF"
-    exit 1
-fi
+WORKDIR $ONVM_HOME
 
-IFS=','
-for DEV in ${RAW_DEVICES} ; do
-    DEVICES+=("--device=$DEV:$DEV")
-done
-
-if [[ "${DIR}" != "" ]] ; then
-    DIR="--volume=${DIR}:/$(basename ${DIR})"
-fi
-
-if [[ "${CMD}" == "" ]] ; then
-    sudo docker run \
-        --interactive --tty \
-        --privileged \
-        --name=${NAME} \
-        --network bridge \
-        --volume=/var/run:/var/run \
-        --volume=${HUGE}:${HUGE} \
-        --volume=${ONVM}:/openNetVM \
-        ${DIR} \
-        ${DEVICES[@]} \
-        sdnfv/opennetvm \
-        /bin/bash
-else
-    sudo docker run \
-        --detach=true \
-        --privileged \
-        --name=${NAME} \
-        --network bridge \
-        --volume=/var/run:/var/run \
-        --volume=${HUGE}:${HUGE} \
-        --volume=${ONVM}:/openNetVM \
-        ${DIR} \
-        ${DEVICES[@]} \
-        sdnfv/opennetvm \
-        /bin/bash -c "${CMD}"
-fi
-
-
+RUN apt-get update && \
+    apt-get install -y build-essential \
+                       gdb \
+                       libnuma-dev \
+                       vim \
+                       less \
+                       git


### PR DESCRIPTION
This change updates the docker.sh script which helps users launch NFs
inside Docker containers.  It removes an unncessary argument, `-w
WORKINGDIRECTORY`, and changes it to launch containers based off of the
new sdnfv/opennetvm Docker image.

This change also provides a Dockerfile which can be used for docker
image creation.  It creates a docker image based off of Ubuntu 14.04
which is what is uploaded to our [Docker Hub
account](https://hub.docker.com/r/sdnfv/opennetvm/).

With the script changes and use of our Dockerhub account, this change
also updates the Docker README in the docs directory to provide the most
up-to-date information about Docker and OpenNetVM.

This will resolve #36 

Testing:

  * Launched a few containers in various topologies in Docker
containers and ensured traffic flowed through the chain and
latency/throughput matched what was expected when running directly on
the host.

**Reviewers:** @twood02 