### PR TITLE
Bug Fix: Prevents speed tester crash if there are no free mbufs

### DIFF
--- a/examples/speed_tester/speed_tester.c
+++ b/examples/speed_tester/speed_tester.c
@@ -411,6 +411,10 @@ int main(int argc, char *argv[]) {
                         int j;
 
                         struct rte_mbuf *pkt = rte_pktmbuf_alloc(pktmbuf_pool);
+                        if (pkt == NULL) {
+                                printf("Failed to allocate packets\n");
+                                break;
+                        }
 
                         /*set up ether header and set new packet size*/
                         ehdr = (struct ether_hdr *) rte_pktmbuf_append(pkt, packet_size);


### PR DESCRIPTION
This resolves #42 where a silent seg fault occurs while `speed_tester` creates packets if there are no free mbufs to allocate.

**Summary:**
If there are no free mbufs, allocation of packets for `speed_tester` fails with no error message. This can occur after restarting `speed_tester` without restarting the manager. This change fixes the issue by checking whether the allocation call returns null, and, if so, printing a message and then breaking out of the for loop to allow `speed_tester` to continue to run with previously created packets.

**Test Plan:**
The procedure to reproduce the issue, running `/openNetVM/examples/speed_tester$ ./go.sh 6 1 1 -c 16000` twice, was followed, and it was observed that the program no longer terminates unexpectedly. Instead, the message `Failed to allocate packets` prints and the process continues to run until the user manually quits.

**Reviewers:** @nks5295 

**Subscribers:** @twood02 
