### PR TITLE
Speed Tester now accepts 0 initial packets

### DIFF
--- a/examples/speed_tester/README.md
+++ b/examples/speed_tester/README.md
@@ -38,3 +38,4 @@ App Specific Arguments
   - `-m DEST_MAC`: User specified destination MAC address, e.g. `-m aa:bb:cc:dd:ee:ff` sets the destination address within the ethernet header that is located at the start of the packet data.
   - `-o PCAP_FILENAME` : The filename of the pcap file to replay
   - `-l LATENCY` : Enable latency measurement. This should only be enabled on one Speed Tester NF. Packets must be routed back to the same speed tester NF.
+  - `-c PACKET_NUMBER` : Use user specified number of packets in the batch. If not specified then this defaults to 128.

--- a/examples/speed_tester/speed_tester.c
+++ b/examples/speed_tester/speed_tester.c
@@ -93,6 +93,8 @@ static uint8_t keep_running = 1;
 static uint16_t packet_size = ETHER_HDR_LEN;
 static uint8_t d_addr_bytes[ETHER_ADDR_LEN];
 
+/*  track the -c option to see if it has been filled */
+static uint8_t if_c = 0;
 /* Default number of packets: 128; user can modify it by -c <packet_number> in command line */
 static uint32_t packet_number = 0;
 
@@ -166,6 +168,7 @@ parse_app_args(int argc, char *argv[], const char *progname) {
                         break;
 #endif
                 case 'c':
+                        if_c = 1;
                         packet_number = strtoul(optarg, NULL, 10);
                         if (packet_number > MAX_PKT_NUM) {
                                 RTE_LOG(INFO, APP, "Illegal packet number(1 ~ %u) %u!\n",
@@ -401,7 +404,8 @@ int main(int argc, char *argv[]) {
                 }
         } else {
 #endif
-                //packet_number = (packet_number? packet_number : DEFAULT_PKT_NUM);
+                /*  use default number of initial packets if -c has not been used */
+                packet_number = (if_c ? packet_number : DEFAULT_PKT_NUM);
 
                 printf("Creating %u packets to send to %u\n", packet_number, destination);
 

--- a/examples/speed_tester/speed_tester.c
+++ b/examples/speed_tester/speed_tester.c
@@ -167,7 +167,7 @@ parse_app_args(int argc, char *argv[], const char *progname) {
 #endif
                 case 'c':
                         packet_number = strtoul(optarg, NULL, 10);
-                        if (packet_number <= 0 || packet_number > MAX_PKT_NUM) {
+                        if (packet_number > MAX_PKT_NUM) {
                                 RTE_LOG(INFO, APP, "Illegal packet number(1 ~ %u) %u!\n",
                                         MAX_PKT_NUM, packet_number);
                                 return -1;
@@ -401,7 +401,7 @@ int main(int argc, char *argv[]) {
                 }
         } else {
 #endif
-                packet_number = (packet_number? packet_number : DEFAULT_PKT_NUM);
+                //packet_number = (packet_number? packet_number : DEFAULT_PKT_NUM);
 
                 printf("Creating %u packets to send to %u\n", packet_number, destination);
 

--- a/examples/speed_tester/speed_tester.c
+++ b/examples/speed_tester/speed_tester.c
@@ -94,7 +94,7 @@ static uint16_t packet_size = ETHER_HDR_LEN;
 static uint8_t d_addr_bytes[ETHER_ADDR_LEN];
 
 /*  track the -c option to see if it has been filled */
-static uint8_t if_c = 0;
+static uint8_t use_custom_pkt_count = 0;
 /* Default number of packets: 128; user can modify it by -c <packet_number> in command line */
 static uint32_t packet_number = 0;
 
@@ -168,7 +168,7 @@ parse_app_args(int argc, char *argv[], const char *progname) {
                         break;
 #endif
                 case 'c':
-                        if_c = 1;
+                        use_custom_pkt_count = 1;
                         packet_number = strtoul(optarg, NULL, 10);
                         if (packet_number > MAX_PKT_NUM) {
                                 RTE_LOG(INFO, APP, "Illegal packet number(1 ~ %u) %u!\n",
@@ -405,7 +405,7 @@ int main(int argc, char *argv[]) {
         } else {
 #endif
                 /*  use default number of initial packets if -c has not been used */
-                packet_number = (if_c ? packet_number : DEFAULT_PKT_NUM);
+                packet_number = (use_custom_pkt_count ? packet_number : DEFAULT_PKT_NUM);
 
                 printf("Creating %u packets to send to %u\n", packet_number, destination);
 


### PR DESCRIPTION
Changes are:
1. Line 170 has been changed to exclude "packet_number <= 0" test. This
stops the program from throwing an error if -c 0 is provided as
argument.
2. Line 404: "packet_number = (packet_number ? packet_number :
DEFAULT_PKT_NUM)" has been commented. This prevents the program from
replacing packet_number = 0 with packet_number = 128 (DEFAULT_PKT_NUM).
This could have also been done by changing DEFAULT_PKT_NUM to 0. But
that might be handy for future usage.

The system now sets packet_number to 0 if -c option is not provided.

**Summary:**
Effectively the default number of packets now is 0 for the speed tester. The original default definition has not been changed for future use.

**Test Plan:**
./onvm/go.sh 0,1,2,3 1 -s stdout
./example/speed_tester/go.sh 5 1 1

(optional) **Reviewers:** @twood02 
(optional) **Subscribers:** 
