### PR TITLE
[Bug Fix]Set the number of NIC TX rings equal to the number of TX threads

### DIFF
--- a/onvm/onvm_mgr/main.c
+++ b/onvm/onvm_mgr/main.c
@@ -255,7 +255,7 @@ main(int argc, char *argv[]) {
         /* clear statistics */
         onvm_stats_clear_all_nfs();
 
-        /* Reserve n cores for: 1 Stats, 1 final Tx out, and ONVM_NUM_RX_THREADS for Rx */
+         /* Reserve n cores for: ONVM_NUM_MGR_AUX_THREADS for auxiliary(f.e. stats), ONVM_NUM_RX_THREADS for Rx, and all remaining for Tx */
         cur_lcore = rte_lcore_id();
         rx_lcores = ONVM_NUM_RX_THREADS;
         tx_lcores = rte_lcore_count() - rx_lcores - ONVM_NUM_MGR_AUX_THREADS;

--- a/onvm/onvm_mgr/main.c
+++ b/onvm/onvm_mgr/main.c
@@ -258,7 +258,7 @@ main(int argc, char *argv[]) {
         /* Reserve n cores for: 1 Stats, 1 final Tx out, and ONVM_NUM_RX_THREADS for Rx */
         cur_lcore = rte_lcore_id();
         rx_lcores = ONVM_NUM_RX_THREADS;
-        tx_lcores = rte_lcore_count() - rx_lcores - 1;
+        tx_lcores = rte_lcore_count() - rx_lcores - ONVM_NUM_MGR_THREADS;
 
         /* Offset cur_lcore to start assigning TX cores */
         cur_lcore += (rx_lcores-1);

--- a/onvm/onvm_mgr/main.c
+++ b/onvm/onvm_mgr/main.c
@@ -258,7 +258,7 @@ main(int argc, char *argv[]) {
         /* Reserve n cores for: 1 Stats, 1 final Tx out, and ONVM_NUM_RX_THREADS for Rx */
         cur_lcore = rte_lcore_id();
         rx_lcores = ONVM_NUM_RX_THREADS;
-        tx_lcores = rte_lcore_count() - rx_lcores - ONVM_NUM_MGR_THREADS;
+        tx_lcores = rte_lcore_count() - rx_lcores - ONVM_NUM_MGR_AUX_THREADS;
 
         /* Offset cur_lcore to start assigning TX cores */
         cur_lcore += (rx_lcores-1);

--- a/onvm/onvm_mgr/onvm_init.c
+++ b/onvm/onvm_mgr/onvm_init.c
@@ -331,7 +331,7 @@ static int
 init_port(uint8_t port_num) {
         const uint16_t rx_rings = ONVM_NUM_RX_THREADS;
         const uint16_t rx_ring_size = RTE_MP_RX_DESC_DEFAULT;
-        /* Set the number of tx_rings equal to the tx threads. Currently, we use 1 stats thread, 1 rx thread,
+        /* Set the number of tx_rings equal to the tx threads. This mimics the onvm_mgr tx thread calculation. */
          * any remanining threads are assigned to tx threads */
         const uint16_t tx_rings = rte_lcore_count() - rx_rings - ONVM_NUM_MGR_AUX_THREADS;
         const uint16_t tx_ring_size = RTE_MP_TX_DESC_DEFAULT;

--- a/onvm/onvm_mgr/onvm_init.c
+++ b/onvm/onvm_mgr/onvm_init.c
@@ -331,9 +331,9 @@ static int
 init_port(uint8_t port_num) {
         const uint16_t rx_rings = ONVM_NUM_RX_THREADS;
         const uint16_t rx_ring_size = RTE_MP_RX_DESC_DEFAULT;
-        /* Currently, we reserve 1 core for stats thread, 1 core for 1 rx thread,
-         * any remanining cores are assigned to tx threads */
-        const uint16_t tx_rings = rte_lcore_count() - rx_rings - ONVM_NUM_MGR_THREADS;
+        /* Set the number of tx_rings equal to the tx threads. Currently, we use 1 stats thread, 1 rx thread,
+         * any remanining threads are assigned to tx threads */
+        const uint16_t tx_rings = rte_lcore_count() - rx_rings - ONVM_NUM_MGR_AUX_THREADS;
         const uint16_t tx_ring_size = RTE_MP_TX_DESC_DEFAULT;
 
         uint16_t q;

--- a/onvm/onvm_mgr/onvm_init.c
+++ b/onvm/onvm_mgr/onvm_init.c
@@ -332,7 +332,6 @@ init_port(uint8_t port_num) {
         const uint16_t rx_rings = ONVM_NUM_RX_THREADS;
         const uint16_t rx_ring_size = RTE_MP_RX_DESC_DEFAULT;
         /* Set the number of tx_rings equal to the tx threads. This mimics the onvm_mgr tx thread calculation. */
-         * any remanining threads are assigned to tx threads */
         const uint16_t tx_rings = rte_lcore_count() - rx_rings - ONVM_NUM_MGR_AUX_THREADS;
         const uint16_t tx_ring_size = RTE_MP_TX_DESC_DEFAULT;
 

--- a/onvm/onvm_mgr/onvm_init.c
+++ b/onvm/onvm_mgr/onvm_init.c
@@ -329,8 +329,11 @@ init_nf_info_pool(void)
  */
 static int
 init_port(uint8_t port_num) {
-        const uint16_t rx_rings = ONVM_NUM_RX_THREADS, tx_rings = MAX_NFS;
+        const uint16_t rx_rings = ONVM_NUM_RX_THREADS;
         const uint16_t rx_ring_size = RTE_MP_RX_DESC_DEFAULT;
+        /* Currently, we reserve 1 core for stats thread, 1 core for 1 rx thread,
+         * any remanining cores are assigned to tx threads */
+        const uint16_t tx_rings = rte_lcore_count() - rx_rings - ONVM_NUM_MGR_THREADS;
         const uint16_t tx_ring_size = RTE_MP_TX_DESC_DEFAULT;
 
         uint16_t q;
@@ -339,6 +342,7 @@ init_port(uint8_t port_num) {
         printf("Port %u init ... \n", (unsigned)port_num);
         printf("Port %u socket id %u ... \n", (unsigned)port_num, (unsigned)rte_eth_dev_socket_id(port_num));
         printf("Port %u Rx rings %u ... \n", (unsigned)port_num, (unsigned)rx_rings);
+        printf("Port %u Tx rings %u ... \n", (unsigned)port_num, (unsigned)tx_rings);
         fflush(stdout);
 
         /* Standard DPDK port initialisation - config port, then set up

--- a/onvm/onvm_mgr/onvm_init.h
+++ b/onvm/onvm_mgr/onvm_init.h
@@ -103,7 +103,7 @@
 #define NO_FLAGS 0
 
 #define ONVM_NUM_RX_THREADS 1
-/* Number of auxiliary threads in manager */
+/* Number of auxiliary threads in manager, 1 reserved for stats */
 #define ONVM_NUM_MGR_AUX_THREADS 1
 
 

--- a/onvm/onvm_mgr/onvm_init.h
+++ b/onvm/onvm_mgr/onvm_init.h
@@ -103,6 +103,8 @@
 #define NO_FLAGS 0
 
 #define ONVM_NUM_RX_THREADS 1
+/* Number of non RX/TX threads in manager */
+#define ONVM_NUM_MGR_THREADS 1
 
 
 /*************************External global variables***************************/

--- a/onvm/onvm_mgr/onvm_init.h
+++ b/onvm/onvm_mgr/onvm_init.h
@@ -103,8 +103,8 @@
 #define NO_FLAGS 0
 
 #define ONVM_NUM_RX_THREADS 1
-/* Number of non RX/TX threads in manager */
-#define ONVM_NUM_MGR_THREADS 1
+/* Number of auxiliary threads in manager */
+#define ONVM_NUM_MGR_AUX_THREADS 1
 
 
 /*************************External global variables***************************/


### PR DESCRIPTION
This resolved the bug #27 and issue #43

**Summary:**
Before, when initializing a port(static int init_port(uint8_t port_num) in onvm_init.c), we set the default number of TX queues to the MAX_NFS macro(typically 16), but for the ports with a maximum support TX queue of less than 16, this initialization can cause ONVM manager crashes.(bug #27)

To resolve,we set the number of NIC TX rings equal to the number of TX threads in the ONVM manager.(issue #43)

Commit log:
* Prevent ONVM manager crash if the NIC supporting fewer than 16 transmit queues


**Test Plan:**
Tested by running the Manager with different number of cores, and checked the TX rings number was the same number of the TX threads.

(optional) **Reviewers:**  @twood02 @nks5295 
