### PR TITLE
Document dpdk tool for cleaning up huge pages

### DIFF
--- a/docs/Install.md
+++ b/docs/Install.md
@@ -184,7 +184,7 @@ Troubleshooting
 
     - Press [18] to install igb_uio driver for Intel NICs
 
-    - Press [22] to setup 2048 2MB hugepages
+    - Press [22] to setup 1024 2MB hugepages
 
     - Press [24] to register the Ethernet ports
 

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -172,8 +172,27 @@ Also, please double check if the environment variables from [step 3](#3-set-up-e
 
 Troubleshooting
 --
+1. **Setting up DPDK manually**
 
-1. **Huge Page Configuration**
+    Our install script helps configure DPDK by using its setup script. Sometimes, it's helpful to troubleshoot a problem by running DPDK's script directly to fix things like misconfigured igb_uio drivers or hugepage regions. 
+    
+    Here are the steps used to install the DPDK components needed by ONVM.
+    
+    Run `dpdk/usertools/dpdk-setup.sh` then:
+    
+    - Press [15] to compile x86_64-native-linuxapp-gcc version
+
+    - Press [18] to install igb_uio driver for Intel NICs
+
+    - Press [22] to setup 2048 2MB hugepages
+
+    - Press [24] to register the Ethernet ports
+
+    - Press [35] to quit the tool
+    
+    After these steps, it should be possible to compile and run onvm. 
+
+2. **Huge Page Configuration**
 
     You can get information about the hugepage configuration with:
 
@@ -185,12 +204,11 @@ Troubleshooting
          - In this case, either kill them manually by hitting Ctrl+C or run `sudo pkill NF_NAME` for every NF that you have ran.
      - The manager and NFs are not running, but something crashed without freeing hugepages.
          - To fix this, please run `sudo rm -rf /mnt/huge/*` to remove all files that contain hugepage data.
-         - An alternative method is to use the dpdk provided tools (the following may have changed since DPDK v18.11): Run `cd dpdk/usertools; sudo ./dpdk-setup.sh` then select "remove hugepage mappings" from the list of options. Then run `$ONVM_HOME/scripts/setup_environment.sh` to remount hugepages.
 
      - The above two cases are not met, something weird is happening:
          - A reboot might fix this problem and free memory
 
-2. **Binding the NIC to the DPDK Driver**
+3. **Binding the NIC to the DPDK Driver**
 
     You can check the current status of NIC port bindings with
 
@@ -234,11 +252,11 @@ Troubleshooting
     0000:05:00.1 '82576 Gigabit Network Connection' if=eth1 drv=igb unused=igb_uio
     0000:07:00.1 '82599EB 10-Gigabit SFI/SFP+ Network Connection' if=eth3 drv=ixgbe unused=igb_uio
     ```
-3. **Exporting $ONVM_HOME**
+4. **Exporting $ONVM_HOME**
 
     If the setup_environment.sh script fails because the environment variable ONVM_HOME is not set, please run this command: `export ONVM_HOME=$ONVM_HOME:CHANGEME_TO_THE_PATH_TO_ONVM_DIR`
 
-4. **Poor Performance**
+5. **Poor Performance**
 
 If you are not getting the expected level of performance, try these:
 

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -185,7 +185,7 @@ Troubleshooting
          - In this case, either kill them manually by hitting Ctrl+C or run `sudo pkill NF_NAME` for every NF that you have ran.
      - The manager and NFs are not running, but something crashed without freeing hugepages.
          - To fix this, please run `sudo rm -rf /mnt/huge/*` to remove all files that contain hugepage data.
-         - An alternative method is to use the dpdk provided tools (the following may have changed since DPDK v18.11): Run `cd dpdk/usertools; sudo ./dpdk-setup.sh` then select "remove hugepage mappings" from the list of options. Then run `$ONVM_HOME/scripts/install.sh` to remount hugepages.
+         - An alternative method is to use the dpdk provided tools (the following may have changed since DPDK v18.11): Run `cd dpdk/usertools; sudo ./dpdk-setup.sh` then select "remove hugepage mappings" from the list of options. Then run `$ONVM_HOME/scripts/setup_environment.sh` to remount hugepages.
 
      - The above two cases are not met, something weird is happening:
          - A reboot might fix this problem and free memory

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -185,6 +185,8 @@ Troubleshooting
          - In this case, either kill them manually by hitting Ctrl+C or run `sudo pkill NF_NAME` for every NF that you have ran.
      - The manager and NFs are not running, but something crashed without freeing hugepages.
          - To fix this, please run `sudo rm -rf /mnt/huge/*` to remove all files that contain hugepage data.
+         - An alternative method is to use the dpdk provided tools (the following may have changed since DPDK v18.11): Run `cd dpdk/usertools; sudo ./dpdk-setup.sh` then select "remove hugepage mappings" from the list of options. Then run `$ONVM_HOME/scripts/install.sh` to remount hugepages.
+
      - The above two cases are not met, something weird is happening:
          - A reboot might fix this problem and free memory
 


### PR DESCRIPTION
Sometimes using `sudo rm -rf /mnt/huge/*` doesn't work while the dpdk setup script can fix the problem. This was posted in the slack but it would be good to have documented.

Style nits welcome!

**Reviewers:**  @twood02 @dreidenbaugh 
