### PR TITLE
Bug fix: Logic for entering a service ID value larger than MAX_SERVICE 

### DIFF
--- a/docs/NF_Dev.md
+++ b/docs/NF_Dev.md
@@ -6,7 +6,7 @@ Overview
 
 The openNetVM manager is comprised of two directories: one containing the source code for the [manager][onvm_mgr] and the second containing the source for the [NF_Lib][onvm_nflib].  The manager is responsible for maintaining state bewteen NFs, routing packets between NICs and NFs, and displaying log messages and/or statistics.  The NF_Lib contains useful libraries to initialize and run NFs and libraries to support NF capabilities: [packet helper][pkt_helper], [flow table][flow_table], [flow director][flow_director], [service chains][srvc_chains], and [message passing][msg_passing].
 
-Currently, our platform supports at most 16 NF instances running at once.  This limit is defined in [onvm_common.h][onvm_common.h:L51].
+Currently, our platform supports at most 128 NF instances running at once and a maximum ID value of 32 for NF's. We currently support a maximum of 32 NF instances per service. These limits are defined in [onvm_common.h][onvm_common.h:L51].  These are parameters developed for experimentation of the platform, and are subject to change.
 
 NFs are run with different arguments in three different tiers--DPDK configuration flags, openNetVM configuration flags, and NF configuration flags--which are separated with `--`.
   - DPDK configuration flags:

--- a/docs/NF_Dev.md
+++ b/docs/NF_Dev.md
@@ -6,7 +6,7 @@ Overview
 
 The openNetVM manager is comprised of two directories: one containing the source code for the [manager][onvm_mgr] and the second containing the source for the [NF_Lib][onvm_nflib].  The manager is responsible for maintaining state bewteen NFs, routing packets between NICs and NFs, and displaying log messages and/or statistics.  The NF_Lib contains useful libraries to initialize and run NFs and libraries to support NF capabilities: [packet helper][pkt_helper], [flow table][flow_table], [flow director][flow_director], [service chains][srvc_chains], and [message passing][msg_passing].
 
-Currently, our platform supports at most 128 NF instances running at once and a maximum ID value of 32 for NF's. We currently support a maximum of 32 NF instances per service. These limits are defined in [onvm_common.h][onvm_common.h:L51].  These are parameters developed for experimentation of the platform, and are subject to change.
+Currently, our platform supports at most 128 NF instances running at once with a maximum ID value of 32 for each NF. We currently support a maximum of 32 NF instances per service. These limits are defined in [onvm_common.h][onvm_common.h:L51].  These are parameters developed for experimentation of the platform, and are subject to change.
 
 NFs are run with different arguments in three different tiers--DPDK configuration flags, openNetVM configuration flags, and NF configuration flags--which are separated with `--`.
   - DPDK configuration flags:

--- a/onvm/onvm_mgr/onvm_nf.c
+++ b/onvm/onvm_mgr/onvm_nf.c
@@ -182,6 +182,12 @@ onvm_nf_start(struct onvm_nf_info *nf_info) {
                 ? onvm_nf_next_instance_id()
                 : nf_info->instance_id;
 
+        if (nf_info->service_id >= MAX_SERVICES) {
+                // Maximum service ID exceeded
+                nf_info->status = NF_SERVICE_MAX;
+                return 1;
+        }
+
         if (nf_id >= MAX_NFS) {
                 // There are no more available IDs for this NF
                 nf_info->status = NF_NO_IDS;
@@ -193,12 +199,7 @@ onvm_nf_start(struct onvm_nf_info *nf_info) {
                 nf_info->status = NF_ID_CONFLICT;
                 return 1;
         }
-
-	if (nf_info->service_id >= MAX_SERVICES) {
-                // This NF service id exceeds the maximum service value
-                nf_info->status = NF_NO_IDS;
-                return 1;
-        }
+        
 
         // Keep reference to this NF in the manager
         nf_info->instance_id = nf_id;

--- a/onvm/onvm_mgr/onvm_nf.c
+++ b/onvm/onvm_mgr/onvm_nf.c
@@ -188,7 +188,7 @@ onvm_nf_start(struct onvm_nf_info *nf_info) {
                 return 1;
         }
 
-        if (nf_info->service_id >= MAX_SERVICES || nf_info->service_id <= 0) {
+        if (nf_info->service_id >= MAX_SERVICES) {
                 // Service ID must be less than MAX_SERVICES and greater than 0
                 nf_info->status = NF_SERVICE_MAX;
                 return 1;

--- a/onvm/onvm_mgr/onvm_nf.c
+++ b/onvm/onvm_mgr/onvm_nf.c
@@ -188,11 +188,13 @@ onvm_nf_start(struct onvm_nf_info *nf_info) {
                 return 1;
         }
 
-        if (nf_info->service_id >= MAX_SERVICES) {
-                // Service ID has exceeded the maximum amount
+        if (nf_info->service_id >= MAX_SERVICES || nf_info->service_id <= 0) {
+                // Service ID must be less than MAX_SERVICES and greater than 0
                 nf_info->status = NF_SERVICE_MAX;
                 return 1;
         }
+
+
 
         if (onvm_nf_is_valid(&nfs[nf_id])) {
                 // This NF is trying to declare an ID already in use

--- a/onvm/onvm_mgr/onvm_nf.c
+++ b/onvm/onvm_mgr/onvm_nf.c
@@ -194,6 +194,11 @@ onvm_nf_start(struct onvm_nf_info *nf_info) {
                 return 1;
         }
 
+        if (nf_per_service_count[nf_info->service_id] >= MAX_NFS_PER_SERVICE) {
+                // Maximum amount of NF's per service spawned
+                nf_info->status = NF_SERVICE_COUNT_MAX;
+                return 1;
+        }
 
 
         if (onvm_nf_is_valid(&nfs[nf_id])) {

--- a/onvm/onvm_mgr/onvm_nf.c
+++ b/onvm/onvm_mgr/onvm_nf.c
@@ -189,7 +189,7 @@ onvm_nf_start(struct onvm_nf_info *nf_info) {
         }
 
         if (nf_info->service_id >= MAX_SERVICES) {
-            // Maximum service ID exceeded
+                // Service ID has exceeded the maximum amount
                 nf_info->status = NF_SERVICE_MAX;
                 return 1;
         }

--- a/onvm/onvm_mgr/onvm_nf.c
+++ b/onvm/onvm_mgr/onvm_nf.c
@@ -200,7 +200,6 @@ onvm_nf_start(struct onvm_nf_info *nf_info) {
                 return 1;
         }
 
-
         if (onvm_nf_is_valid(&nfs[nf_id])) {
                 // This NF is trying to declare an ID already in use
                 nf_info->status = NF_ID_CONFLICT;

--- a/onvm/onvm_mgr/onvm_nf.c
+++ b/onvm/onvm_mgr/onvm_nf.c
@@ -205,7 +205,6 @@ onvm_nf_start(struct onvm_nf_info *nf_info) {
                 nf_info->status = NF_ID_CONFLICT;
                 return 1;
         }
-        
 
         // Keep reference to this NF in the manager
         nf_info->instance_id = nf_id;

--- a/onvm/onvm_mgr/onvm_nf.c
+++ b/onvm/onvm_mgr/onvm_nf.c
@@ -194,6 +194,12 @@ onvm_nf_start(struct onvm_nf_info *nf_info) {
                 return 1;
         }
 
+	if (nf_info->service_id >= MAX_SERVICES) {
+                // This NF service id exceeds the maximum service value
+                nf_info->status = NF_NO_IDS;
+                return 1;
+        }
+
         // Keep reference to this NF in the manager
         nf_info->instance_id = nf_id;
         nfs[nf_id].info = nf_info;

--- a/onvm/onvm_mgr/onvm_nf.c
+++ b/onvm/onvm_mgr/onvm_nf.c
@@ -182,15 +182,15 @@ onvm_nf_start(struct onvm_nf_info *nf_info) {
                 ? onvm_nf_next_instance_id()
                 : nf_info->instance_id;
 
-        if (nf_info->service_id >= MAX_SERVICES) {
-                // Maximum service ID exceeded
-                nf_info->status = NF_SERVICE_MAX;
-                return 1;
-        }
-
         if (nf_id >= MAX_NFS) {
                 // There are no more available IDs for this NF
                 nf_info->status = NF_NO_IDS;
+                return 1;
+        }
+
+        if (nf_info->service_id >= MAX_SERVICES) {
+            // Maximum service ID exceeded
+                nf_info->status = NF_SERVICE_MAX;
                 return 1;
         }
 

--- a/onvm/onvm_nflib/onvm_common.h
+++ b/onvm/onvm_nflib/onvm_common.h
@@ -271,6 +271,7 @@ struct onvm_service_chain {
 #define NF_STOPPED 4            // NF has stopped and in the shutdown process
 #define NF_ID_CONFLICT 5        // NF is trying to declare an ID already in use
 #define NF_NO_IDS 6             // There are no available IDs for this NF
+#define NF_SERVICE_MAX 7        // Service id has reached its max
 
 #define NF_NO_ID -1
 #define ONVM_NF_HANDLE_TX 1     // should be true if NFs primarily pass packets to each other

--- a/onvm/onvm_nflib/onvm_common.h
+++ b/onvm/onvm_nflib/onvm_common.h
@@ -272,6 +272,7 @@ struct onvm_service_chain {
 #define NF_ID_CONFLICT 5        // NF is trying to declare an ID already in use
 #define NF_NO_IDS 6             // There are no available IDs for this NF
 #define NF_SERVICE_MAX 7        // Service ID has exceeded the maximum amount
+#define NF_SERVICE_COUNT_MAX 8          // Maximum amount of NF's per service spawned
 
 #define NF_NO_ID -1
 #define ONVM_NF_HANDLE_TX 1     // should be true if NFs primarily pass packets to each other

--- a/onvm/onvm_nflib/onvm_common.h
+++ b/onvm/onvm_nflib/onvm_common.h
@@ -271,7 +271,7 @@ struct onvm_service_chain {
 #define NF_STOPPED 4            // NF has stopped and in the shutdown process
 #define NF_ID_CONFLICT 5        // NF is trying to declare an ID already in use
 #define NF_NO_IDS 6             // There are no available IDs for this NF
-#define NF_SERVICE_MAX 7        // Service id has reached its max
+#define NF_SERVICE_MAX 7        // Service ID has exceeded the maximum amount
 
 #define NF_NO_ID -1
 #define ONVM_NF_HANDLE_TX 1     // should be true if NFs primarily pass packets to each other

--- a/onvm/onvm_nflib/onvm_common.h
+++ b/onvm/onvm_nflib/onvm_common.h
@@ -272,7 +272,7 @@ struct onvm_service_chain {
 #define NF_ID_CONFLICT 5        // NF is trying to declare an ID already in use
 #define NF_NO_IDS 6             // There are no available IDs for this NF
 #define NF_SERVICE_MAX 7        // Service ID has exceeded the maximum amount
-#define NF_SERVICE_COUNT_MAX 8          // Maximum amount of NF's per service spawned
+#define NF_SERVICE_COUNT_MAX 8  // Maximum amount of NF's per service spawned
 
 #define NF_NO_ID -1
 #define ONVM_NF_HANDLE_TX 1     // should be true if NFs primarily pass packets to each other

--- a/onvm/onvm_nflib/onvm_nflib.c
+++ b/onvm/onvm_nflib/onvm_nflib.c
@@ -315,6 +315,9 @@ onvm_nflib_start_nf(struct onvm_nf_info *nf_info) {
         if (nf_info->status == NF_ID_CONFLICT) {
                 rte_mempool_put(nf_info_mp, nf_info);
                 rte_exit(NF_ID_CONFLICT, "Selected ID already in use. Exiting...\n");
+        } else if (nf_info->status == NF_SERVICE_MAX) {
+                rte_mempool_put(nf_info_mp, nf_info);
+                rte_exit(NF_SERVICE_MAX, "Service ID has exceeded the maximum amount\n");
         } else if(nf_info->status == NF_NO_IDS) {
                 rte_mempool_put(nf_info_mp, nf_info);
                 rte_exit(NF_NO_IDS, "There are no ids available for this NF\n");

--- a/onvm/onvm_nflib/onvm_nflib.c
+++ b/onvm/onvm_nflib/onvm_nflib.c
@@ -317,7 +317,7 @@ onvm_nflib_start_nf(struct onvm_nf_info *nf_info) {
                 rte_exit(NF_ID_CONFLICT, "Selected ID already in use. Exiting...\n");
         } else if (nf_info->status == NF_SERVICE_MAX) {
                 rte_mempool_put(nf_info_mp, nf_info);
-                rte_exit(NF_SERVICE_MAX, "Service ID has exceeded the maximum amount\n");
+                rte_exit(NF_SERVICE_MAX, "Service ID must be less than %d\n", MAX_SERVICES);
         } else if(nf_info->status == NF_NO_IDS) {
                 rte_mempool_put(nf_info_mp, nf_info);
                 rte_exit(NF_NO_IDS, "There are no ids available for this NF\n");

--- a/onvm/onvm_nflib/onvm_nflib.c
+++ b/onvm/onvm_nflib/onvm_nflib.c
@@ -317,7 +317,7 @@ onvm_nflib_start_nf(struct onvm_nf_info *nf_info) {
                 rte_exit(NF_ID_CONFLICT, "Selected ID already in use. Exiting...\n");
         } else if (nf_info->status == NF_SERVICE_MAX) {
                 rte_mempool_put(nf_info_mp, nf_info);
-                rte_exit(NF_SERVICE_MAX, "Service ID must be less than %d\n", MAX_SERVICES);
+                rte_exit(NF_SERVICE_MAX, "Service ID must be less than %d and greater than 0\n", MAX_SERVICES);
         } else if(nf_info->status == NF_NO_IDS) {
                 rte_mempool_put(nf_info_mp, nf_info);
                 rte_exit(NF_NO_IDS, "There are no ids available for this NF\n");

--- a/onvm/onvm_nflib/onvm_nflib.c
+++ b/onvm/onvm_nflib/onvm_nflib.c
@@ -320,7 +320,7 @@ onvm_nflib_start_nf(struct onvm_nf_info *nf_info) {
                 rte_exit(NF_SERVICE_MAX, "Service ID must be less than %d\n", MAX_SERVICES);
         } else if (nf_info->status == NF_SERVICE_COUNT_MAX) {
                 rte_mempool_put(nf_info_mp, nf_info);
-                rte_exit(NF_COUNT_MAX, "Maximum amount of NF's per service spawned, must be less than %d", MAX_NFS_PER_SERVICE);
+                rte_exit(NF_SERVICE_COUNT_MAX, "Maximum amount of NF's per service spawned, must be less than %d", MAX_NFS_PER_SERVICE);
         } else if(nf_info->status == NF_NO_IDS) {
                 rte_mempool_put(nf_info_mp, nf_info);
                 rte_exit(NF_NO_IDS, "There are no ids available for this NF\n");

--- a/onvm/onvm_nflib/onvm_nflib.c
+++ b/onvm/onvm_nflib/onvm_nflib.c
@@ -318,6 +318,9 @@ onvm_nflib_start_nf(struct onvm_nf_info *nf_info) {
         } else if (nf_info->status == NF_SERVICE_MAX) {
                 rte_mempool_put(nf_info_mp, nf_info);
                 rte_exit(NF_SERVICE_MAX, "Service ID must be less than %d\n", MAX_SERVICES);
+        } else if (nf_info->status == NF_SERVICE_COUNT_MAX) {
+                rte_mempool_put(nf_info_mp, nf_info);
+                rte_exit(NF_COUNT_MAX, "Maximum amount of NF's per service spawned, must be less than %d", MAX_NFS_PER_SERVICE);
         } else if(nf_info->status == NF_NO_IDS) {
                 rte_mempool_put(nf_info_mp, nf_info);
                 rte_exit(NF_NO_IDS, "There are no ids available for this NF\n");

--- a/onvm/onvm_nflib/onvm_nflib.c
+++ b/onvm/onvm_nflib/onvm_nflib.c
@@ -317,7 +317,7 @@ onvm_nflib_start_nf(struct onvm_nf_info *nf_info) {
                 rte_exit(NF_ID_CONFLICT, "Selected ID already in use. Exiting...\n");
         } else if (nf_info->status == NF_SERVICE_MAX) {
                 rte_mempool_put(nf_info_mp, nf_info);
-                rte_exit(NF_SERVICE_MAX, "Service ID must be less than %d and greater than 0\n", MAX_SERVICES);
+                rte_exit(NF_SERVICE_MAX, "Service ID must be less than %d\n", MAX_SERVICES);
         } else if(nf_info->status == NF_NO_IDS) {
                 rte_mempool_put(nf_info_mp, nf_info);
                 rte_exit(NF_NO_IDS, "There are no ids available for this NF\n");


### PR DESCRIPTION
Fixes a bug related to entering a service ID larger than the defined macro MAX_SERVICE.  

**Summary:**
Upon entering a service ID greater than 31 as a command line argument in the initialization of a NF, an open manager would crash. This references this opened [issue. ](https://github.com/sdnfv/openNetVM/issues/64)
**Test Plan:**
Tested on speed_tester. Plan to test on other NF's for thoroughness. 
