### PR TITLE
Replacing deprecated function rte_ctrlmbuf_data for speed_tester pcap usage

### DIFF
--- a/examples/speed_tester/speed_tester.c
+++ b/examples/speed_tester/speed_tester.c
@@ -398,7 +398,7 @@ nf_setup(struct onvm_nf_info *nf_info) {
                         pkt->data_len = header.caplen;
 
                         /* Copy the packet into the rte_mbuf data section */
-                        rte_memcpy(rte_ctrlmbuf_data(pkt), packet, header.caplen);
+                        rte_memcpy(rte_pktmbuf_mtod(pkt, char*), packet, header.caplen);
 
                         pmeta = onvm_get_pkt_meta(pkt);
                         pmeta->destination = destination;


### PR DESCRIPTION
rte_ctrlmbuf_data was removed in DPDK 18.05. This caused errors when attempting to use pcap files with speed_tester

<!-- Add detailed description and provide running instructions -->
## Summary:
Replaces rte_ctrlmbuf_data(pkt) with rte_pktmbuf_mtod(pkt, char*) as suggested by @koolzz . This will retrieve packet data as the deprecated function did. This was noted in DPDK 18.05 release notes.

**Usage:**

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                | 👍🏻
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [x] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:
Verify speed_tester works with ENABLE_PCAP=1 and -o flag set, use flow_tracker to see if pcap is applied. 
Already tested. Could use sanity checks. 

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
* Sanity checks, assigned to @koolzz 
  * Run make in /onvm and /examples directories
  * Test new functionality or bug fix from the pr (if needed)

* Code style, assigned to @koolzz 
  * Run linter
  * Check everything style related

* Code design, assigned to @koolzz 

  * Check for memory leaks
  * Check that code is reusable
  * Code is clean, functions are concise
  * Verify that edge cases properly handled

* Performance, assigned to @koolzz 
  * Run Speed Tester NF, report performance.
  * Run pktgen, report performance (if needed)
  * Run mTCP epserver, verify wget works, report performance for epwget/ab (if needed)

* Documentation, assigned to @koolzz 
  * Check if the new changes are well documented, in both code and READMEs