### PR TITLE
Decrease MAX_NFS number to improve performance

### DIFF
--- a/onvm/onvm_nflib/onvm_common.h
+++ b/onvm/onvm_nflib/onvm_common.h
@@ -51,7 +51,7 @@
 #include "onvm_config_common.h"
 
 #define ONVM_MAX_CHAIN_LENGTH 4   // the maximum chain length
-#define MAX_NFS 128               // total number of NFs allowed
+#define MAX_NFS 32                // total number of NFs allowed
 #define MAX_SERVICES 32           // total number of unique services allowed
 #define MAX_NFS_PER_SERVICE 32    // max number of NFs per service.
 


### PR DESCRIPTION
Change number of MAX_NFS to 32, from 128. 

<!-- Add detailed description and provide running instructions -->
## Summary:
We're observing performance regression from the last few releases, this is one of them.

**Usage:**
Run basic monitor and pktgen 

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                | 
| New functionality        | 
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [ ] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:
On a 2 node setup, one node running onvm_mgr+basic monitor NF and the other node running pktgen.
Confirm the performance increase

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
We wanna merge this fast so I'm encouraging  anyone who can quickly test this and confirm this to review. @lyuxiaosu @dennisafa @kevindweb