### PR TITLE
Fix mbuf number to a static constant

### DIFF
--- a/onvm/onvm_mgr/onvm_init.c
+++ b/onvm/onvm_mgr/onvm_init.c
@@ -265,14 +265,11 @@ init(int argc, char *argv[]) {
  */
 static int
 init_mbuf_pools(void) {
-        const unsigned num_mbufs = (MAX_NFS * MBUFS_PER_NF) \
-                        + (ports->num_ports * MBUFS_PER_PORT);
-
         /* don't pass single-producer/single-consumer flags to mbuf create as it
          * seems faster to use a cache instead */
         printf("Creating mbuf pool '%s' [%u mbufs] ...\n",
-                        PKTMBUF_POOL_NAME, num_mbufs);
-        pktmbuf_pool = rte_mempool_create(PKTMBUF_POOL_NAME, num_mbufs,
+                        PKTMBUF_POOL_NAME, NUM_MBUFS);
+        pktmbuf_pool = rte_mempool_create(PKTMBUF_POOL_NAME, NUM_MBUFS,
                         MBUF_SIZE, MBUF_CACHE_SIZE,
                         sizeof(struct rte_pktmbuf_pool_private), rte_pktmbuf_pool_init,
                         NULL, rte_pktmbuf_init, NULL, rte_socket_id(), NO_FLAGS);

--- a/onvm/onvm_mgr/onvm_init.h
+++ b/onvm/onvm_mgr/onvm_init.h
@@ -83,8 +83,6 @@
 /***********************************Macros************************************/
 
 
-#define MBUFS_PER_NF 1536
-#define MBUFS_PER_PORT 1536
 #define MBUF_CACHE_SIZE 512
 #define MBUF_OVERHEAD (sizeof(struct rte_mbuf) + RTE_PKTMBUF_HEADROOM)
 #define RX_MBUF_DATA_SIZE 2048

--- a/onvm/onvm_nflib/onvm_common.h
+++ b/onvm/onvm_nflib/onvm_common.h
@@ -55,7 +55,7 @@
 #define MAX_SERVICES 32         // total number of unique services allowed
 #define MAX_NFS_PER_SERVICE 32  // max number of NFs per service.
 
-#define NUM_MBUFS 32768         // total number of mbufs
+#define NUM_MBUFS 32767         // total number of mbufs (2^15 - 1)
 #define NF_QUEUE_RINGSIZE 16384 //size of queue for NFs
 
 #define PACKET_READ_SIZE ((uint16_t)32)

--- a/onvm/onvm_nflib/onvm_common.h
+++ b/onvm/onvm_nflib/onvm_common.h
@@ -50,11 +50,12 @@
 #include "onvm_msg_common.h"
 #include "onvm_config_common.h"
 
-#define ONVM_MAX_CHAIN_LENGTH 4   // the maximum chain length
-#define MAX_NFS 128               // total number of NFs allowed
-#define MAX_SERVICES 32           // total number of unique services allowed
-#define MAX_NFS_PER_SERVICE 32    // max number of NFs per service.
+#define ONVM_MAX_CHAIN_LENGTH 4 // the maximum chain length
+#define MAX_NFS 128             // total number of NFs allowed
+#define MAX_SERVICES 32         // total number of unique services allowed
+#define MAX_NFS_PER_SERVICE 32  // max number of NFs per service.
 
+#define NUM_MBUFS 32768         // total number of mbufs
 #define NF_QUEUE_RINGSIZE 16384 //size of queue for NFs
 
 #define PACKET_READ_SIZE ((uint16_t)32)


### PR DESCRIPTION
This changes the mbuf size to a constant, instead of a dynamically computed number.

<!-- Add detailed description and provide running instructions -->
## Summary:
We're observing performance regression from the last few releases, this is one of them. This PR boost pktgen performance from 7Mpps -> (13-14) Mpps, its  a different approach from #78, performance is affected as size of mbufs is directly proportional to the max_nfs number. 
The best performance we were getting is around 16-32 MAX_NFS number. This computes to a value between **27648** `(16*1536 + 1536*2)` and **52224** `(32*1536 + 1536*2)`. From [dpdk docs](http://doc.dpdk.org/api/rte__mempool_8h.html#a503f2f889043a48ca9995878846db2fd), selected 32767 (2^15-1) as its between those and other numbers tend to have the same performance. 

Before
---
```
- Ports 0-0 of 1   <Main Page>  Copyright (c) <2010-2019>, Intel Corporation                                                                           [0/897]
  Flags:Port        :   P--------------:0
Link State          :       <UP-10000-FD>     ----TotalRate----
Pkts/s Max/Rx       :     7714439/7687112       7714439/7687112
       Max/Tx       :   14751018/14739266     14751018/14739266
MBits/s Rx/Tx       :           5165/9904             5165/9904
Broadcast           :                   0
Multicast           :                   0
Sizes 64            :            23335868
      65-127        :                   0
      128-255       :                   0
      256-511       :                   4
      512-1023      :                   0
      1024-1518     :                   0
Runts/Jumbos        :                 0/0
ARP/ICMP Pkts       :                 0/0
Errors Rx/Tx        :                 0/0
Total Rx Pkts       :            17553840
      Tx Pkts       :            33658057
      Rx MBs        :               11796
      Tx MBs        :               22618
                    :
Pattern Type        :             abcd...
Tx Count/% Rate     :     100000000 /100%
Pkt Size/Tx Burst   :           64 /   32
Port Src/Dest       :         1234 / 1234
Pkt Type:VLAN ID    :     IPv4 / UDP:0001
802.1p CoS/DSCP/IPP :           0/  0/  0
VxLAN Flg/Grp/vid   :    0000/    0/    0
IP  Destination     :          10.11.1.17
    Source          :        10.11.1.17/0
MAC Destination     :   90:e2:ba:b3:b9:91
    Source          :   90:e2:ba:b3:75:c0
PCI Vendor/Addr     :   8086:10fb/06:00.0

-- Pktgen Ver: 3.6.5 (DPDK 18.11.0)  Powered by DPDK  (pid:9331) --------------
  ["singlePktIdx"] = 16,
  ["Lua_Version"] = "Lua 5.3",
  ["maxTOS"] = 255,
}
Port Count 1
Total port Count 1

Pktgen:/> start all

```

After
---
```
| Ports 0-0 of 1   <Main Page>  Copyright (c) <2010-2019>, Intel Corporation                                                                          [0/1147]
  Flags:Port        :   P--------------:0
Link State          :       <UP-10000-FD>     ----TotalRate----
Pkts/s Max/Rx       :   13146367/13146367     13146367/13146367
       Max/Tx       :   14781353/14781353     14781353/14781353
MBits/s Rx/Tx       :           8834/9933             8834/9933
Broadcast           :                   0
Multicast           :                   0
Sizes 64            :            78524339
      65-127        :                   0
      128-255       :                   0
      256-511       :                   4
      512-1023      :                   0
      1024-1518     :                   0
Runts/Jumbos        :                 0/0
ARP/ICMP Pkts       :                 0/0
Errors Rx/Tx        :                 0/0
Total Rx Pkts       :            67104835
      Tx Pkts       :            75923081
      Rx MBs        :               45094
      Tx MBs        :               51020
                    :
Pattern Type        :             abcd...
Tx Count/% Rate     :     100000000 /100%
Pkt Size/Tx Burst   :           64 /   32
Port Src/Dest       :         1234 / 1234
Pkt Type:VLAN ID    :     IPv4 / UDP:0001
802.1p CoS/DSCP/IPP :           0/  0/  0
VxLAN Flg/Grp/vid   :    0000/    0/    0
IP  Destination     :          10.11.1.17
    Source          :        10.11.1.17/0
MAC Destination     :   90:e2:ba:b3:b9:91
    Source          :   90:e2:ba:b3:75:c0
PCI Vendor/Addr     :   8086:10fb/06:00.0

-- Pktgen Ver: 3.6.5 (DPDK 18.11.0)  Powered by DPDK  (pid:9602) --------------
  ["minCos"] = 0,
  ["Lua_Copyright"] = "Lua 5.3.5  Copyright (C) 1994-2018 Lua.org, PUC-Rio",
  ["numTotalPkts"] = 28,
  ["pingPktIdx"] = 17,
}
Port Count 1
Total port Count 1
s         start all

```

**Usage:**
Run basic monitor and pktgen 

onvm_mgr - `./go.sh 0,1,2,3 1 0x10 -s stdout`
Basic Monitor - ./go.sh 1


<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                |
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [x] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:
Try to test if this is the best number.

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
@sameergk was this what you were using?
Review: @lyuxiaosu @dennisafa @kevindweb