### PR TITLE
Changes pktgen submodule to upstrem pktgen

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,5 +5,5 @@
         commit = 0da7f445df445630c794897347ee360d6fe6348b
 [submodule "tools/Pktgen/pktgen-dpdk"]
         path = tools/Pktgen/pktgen-dpdk
-        url = ../../sdnfv/onvm-pktgen.git
-        branch = onvm
+        url = http://dpdk.org/git/apps/pktgen-dpdk
+        commit = 3942af7912f244c3e5f9e70b761851c9662019eb 

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,5 @@
 [submodule "tools/Pktgen/pktgen-dpdk"]
         path = tools/Pktgen/pktgen-dpdk
         url = http://dpdk.org/git/apps/pktgen-dpdk
-        commit = 3942af7912f244c3e5f9e70b761851c9662019eb 
+        branch = master
+        commit = 4199555481cd08fe08e32986c94e59836ca1cd4f 

--- a/tools/Pktgen/README.md
+++ b/tools/Pktgen/README.md
@@ -96,9 +96,9 @@ Script files are located in openNetVM-Scripts
 2.4 Run pktgen
 ------------- 
 
-`$cd openNetVM-Scripts`
-
-`$sudo bash run-pktgen.sh 1` or `$sudo bash run-pktgen.sh 2` 
+```sh
+./openNetVM-Scripts/run-pktgen.sh 1
+```   
 
 If you got your result as below, then you are all set
 ```

--- a/tools/Pktgen/openNetVM-Scripts/pktgen-config.lua
+++ b/tools/Pktgen/openNetVM-Scripts/pktgen-config.lua
@@ -1,0 +1,78 @@
+--                    openNetVM
+--      https://github.com/sdnfv/openNetVM
+--
+-- BSD LICENSE
+--
+-- Copyright(c)
+--          2015-2016 George Washington University
+--          2015-2016 University of California Riverside
+-- All rights reserved.
+
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions
+-- are met:
+
+-- Redistributions of source code must retain the above copyright
+-- notice, this list of conditions and the following disclaimer.
+-- Redistributions in binary form must reproduce the above copyright
+-- notice, this list of conditions and the following disclaimer in
+-- the documentation and/or other materials provided with the
+-- distribution.
+-- The name of the author may not be used to endorse or promote
+-- products derived from this software without specific prior
+-- written permission.
+
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+-- "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+-- LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+-- A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+-- OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+-- SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+-- LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+-- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+-- THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-- Change any of the settings below to configure Pktgen-DPDK
+
+-- A list of the test script for Pktgen and Lua.
+-- Each command somewhat mirrors the pktgen command line versions.
+-- A couple of the arguments have be changed to be more like the others.
+
+package.path = package.path ..";?.lua;test/?.lua;app/?.lua;"
+
+require "Pktgen"
+
+printf("Lua Version      : %s\n", pktgen.info.Lua_Version);
+printf("Pktgen Version   : %s\n", pktgen.info.Pktgen_Version);
+printf("Pktgen Copyright : %s\n", pktgen.info.Pktgen_Copyright);
+
+prints("pktgen.info", pktgen.info);
+
+printf("Port Count %d\n", pktgen.portCount());
+printf("Total port Count %d\n", pktgen.totalPorts());
+
+
+-- set up a mac address to set flow to 
+--  
+-- TO DO LIST:
+--
+-- Please update this part with the destination mac address, source and destination ip address you would like to sent packets to 
+
+pktgen.set_mac("0", "90:e2:ba:5e:73:6c"); 
+pktgen.set_ipaddr("0", "dst", "10.11.1.17");
+pktgen.set_ipaddr("0", "src", "10.11.1.16");
+
+pktgen.set_proto("all", "udp");
+pktgen.set_type("all", "ipv4");
+
+pktgen.set("all", "size", 64)
+pktgen.set("all", "burst", 32);
+pktgen.set("all", "sport", 1234);
+pktgen.set("all", "dport", 1234);
+pktgen.set("all", "count", 100000000);
+pktgen.set("all", "rate",100);
+
+pktgen.vlan_id("all", "start", 1);
+

--- a/tools/Pktgen/openNetVM-Scripts/run-pktgen.sh
+++ b/tools/Pktgen/openNetVM-Scripts/run-pktgen.sh
@@ -40,14 +40,17 @@
 # These are the interfaces that you do not want to use for Pktgen-DPDK
 BLACK_LIST="-b 0000:05:00.0 -b 0000:05:00.1"
 
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+
 # Path for pktgen
-PKTGEN_HOME="$ONVM_HOME/tools/Pktgen/pktgen-dpdk/"
+PKTGEN_HOME="$SCRIPTPATH/../pktgen-dpdk/"
 
 # Path for pktgen binary
 PKTGEN_BUILD="./app/x86_64-native-linuxapp-gcc/pktgen"
 
 # Path for pktgen config
-PKTGEN_CONFIG="$ONVM_HOME/tools/Pktgen/openNetVM-Scripts/pktgen-config.lua"
+PKTGEN_CONFIG="$SCRIPTPATH/pktgen-config.lua"
 
 if [ "$#" -lt 1 ] ; then
     echo "Pass an argument for port count"
@@ -58,11 +61,10 @@ fi
 PORT_NUM=$1
 
 echo "Starting pktgen"
-
-if [ $PORT_NUM = 2 ]; then
-    (cd $PKTGEN_HOME && sudo $PKTGEN_BUILD -c 0xff -n 3 $BLACK_LIST -- -p $PORT_MASK -P -m "[1:3].0 [4:8].1" -f $PKTGEN_CONFIG)
-elif [ $PORT_NUM = 1 ]; then
-    (cd $PKTGEN_HOME && sudo $PKTGEN_BUILD -c 0xff -n 3 $BLACK_LIST -- -p $PORT_MASK -P -m "[1:8].0" -f $PKTGEN_CONFIG)
+if [ $PORT_NUM  -eq "2" ]; then
+    (cd $PKTGEN_HOME && sudo $PKTGEN_BUILD -c 0xff -n 3 $BLACK_LIST -- -p 0x3 $PORT_MASK -P -m "[1:2].0, [3:4].1" -f $PKTGEN_CONFIG)
+elif [ $PORT_NUM -eq "1" ]; then
+    (cd $PKTGEN_HOME && sudo $PKTGEN_BUILD -c 0xff -n 3 $BLACK_LIST -- -p 0x1 $PORT_MASK -P -m "[1:2].0" -f $PKTGEN_CONFIG)
 else
     echo "Only supports 1 or 2 ports"
     exit 0

--- a/tools/Pktgen/openNetVM-Scripts/run-pktgen.sh
+++ b/tools/Pktgen/openNetVM-Scripts/run-pktgen.sh
@@ -61,12 +61,14 @@ fi
 PORT_NUM=$1
 
 echo "Starting pktgen"
+
+# Pktgen has to be started from pktgen-dpdk/
 if [ $PORT_NUM  -eq "2" ]; then
     (cd $PKTGEN_HOME && sudo $PKTGEN_BUILD -c 0xff -n 3 $BLACK_LIST -- -p 0x3 $PORT_MASK -P -m "[1:2].0, [3:4].1" -f $PKTGEN_CONFIG)
 elif [ $PORT_NUM -eq "1" ]; then
     (cd $PKTGEN_HOME && sudo $PKTGEN_BUILD -c 0xff -n 3 $BLACK_LIST -- -p 0x1 $PORT_MASK -P -m "[1:2].0" -f $PKTGEN_CONFIG)
 else
-    echo "Only supports 1 or 2 ports"
+    echo "Helper script only supports 1 or 2 ports"
     exit 0
 fi
 

--- a/tools/Pktgen/openNetVM-Scripts/run-pktgen.sh
+++ b/tools/Pktgen/openNetVM-Scripts/run-pktgen.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+#                    openNetVM
+#      https://github.com/sdnfv/openNetVM
+#
+# BSD LICENSE
+#
+# Copyright(c)
+#          2015-2016 George Washington University
+#          2015-2016 University of California Riverside
+#          2010-2014 Intel Corporation.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+# Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in
+# the documentation and/or other materials provided with the
+# distribution.
+# The name of the author may not be used to endorse or promote
+# products derived from this software without specific prior
+# written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# These are the interfaces that you do not want to use for Pktgen-DPDK
+BLACK_LIST="-b 0000:05:00.0 -b 0000:05:00.1"
+
+# Path for pktgen
+PKTGEN_HOME="$ONVM_HOME/tools/Pktgen/pktgen-dpdk/"
+
+# Path for pktgen binary
+PKTGEN_BUILD="./app/x86_64-native-linuxapp-gcc/pktgen"
+
+# Path for pktgen config
+PKTGEN_CONFIG="$ONVM_HOME/tools/Pktgen/openNetVM-Scripts/pktgen-config.lua"
+
+if [ "$#" -lt 1 ] ; then
+    echo "Pass an argument for port count"
+    echo "Example usage: sudo bash run-pktgen.sh 1"
+    exit 0
+fi
+
+PORT_NUM=$1
+
+echo "Starting pktgen"
+
+if [ $PORT_NUM = 2 ]; then
+    (cd $PKTGEN_HOME && sudo $PKTGEN_BUILD -c 0xff -n 3 $BLACK_LIST -- -p $PORT_MASK -P -m "[1:3].0 [4:8].1" -f $PKTGEN_CONFIG)
+elif [ $PORT_NUM = 1 ]; then
+    (cd $PKTGEN_HOME && sudo $PKTGEN_BUILD -c 0xff -n 3 $BLACK_LIST -- -p $PORT_MASK -P -m "[1:8].0" -f $PKTGEN_CONFIG)
+else
+    echo "Only supports 1 or 2 ports"
+    exit 0
+fi
+
+echo "Pktgen done"


### PR DESCRIPTION
Instead of using onvm-pktgen use the regular pktgen submodule


<!-- Add detailed description and provide running instructions -->
## Summary:
This eliminates our last custom submodule. No more maintaining pain!
 - This should fix pktgen from being frozen and not printing packets (@twood02)

**Usage:**
Run script with `./openNetVM-Scripts/run-pktgen.sh 1` or `./openNetVM-Scripts/run-pktgen.sh 1`

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  :+1: 
| Bug fixes                |
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [x] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:
Run pktgen! Testing this goes really well with #79.

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
Person who reviews this can score double points by also reviewing #79 at the same time. A rare opportunity, take it while its still available.
@lyuxiaosu @dennisafa @kevindweb (No need for multiple people to review, this is a simple change, as long as it build & runs we're fine)
