### PR TITLE
Json mem leak

### DIFF
--- a/onvm/onvm_mgr/onvm_stats.c
+++ b/onvm/onvm_mgr/onvm_stats.c
@@ -176,7 +176,6 @@ onvm_stats_cleanup(void) {
         }
 }
 
-
 void
 onvm_stats_display_all(unsigned difftime, uint8_t verbosity_level) {
         time_t time_raw_format;

--- a/onvm/onvm_mgr/onvm_stats.c
+++ b/onvm/onvm_mgr/onvm_stats.c
@@ -170,9 +170,9 @@ onvm_stats_cleanup(void) {
                 fclose(stats_out);
                 fclose(json_stats_out);
                 fclose(json_events_out);
-		/* Delete all JSON objects to free memory */
-		cJSON_Delete(onvm_json_root);
-		cJSON_Delete(onvm_json_events_arr);
+                /* Delete all JSON objects to free memory */
+                cJSON_Delete(onvm_json_root);
+                cJSON_Delete(onvm_json_events_arr);
         }
 }
 

--- a/onvm/onvm_mgr/onvm_stats.c
+++ b/onvm/onvm_mgr/onvm_stats.c
@@ -57,6 +57,7 @@
 
 /************************Internal Functions Prototypes************************/
 
+
 /*
  * Function displaying statistics for all ports
  *
@@ -255,6 +256,7 @@ onvm_stats_add_event(const char *msg, struct onvm_nf_info *nf_info) {
 
 
 /****************************Internal functions*******************************/
+
 
 static void
 onvm_stats_display_ports(unsigned difftime, uint8_t verbosity_level) {

--- a/onvm/onvm_mgr/onvm_stats.c
+++ b/onvm/onvm_mgr/onvm_stats.c
@@ -58,12 +58,6 @@
 /************************Internal Functions Prototypes************************/
 
 /*
- * Function helps delete lists of cJSON objects
- */
-static void
-cJSON_DeleteArray(cJSON **arr, unsigned length);
-
-/*
  * Function displaying statistics for all ports
  *
  * Input : time passed since last display (to compute packet rate)
@@ -176,13 +170,9 @@ onvm_stats_cleanup(void) {
                 fclose(stats_out);
                 fclose(json_stats_out);
                 fclose(json_events_out);
-		/* Delete all JSON objects to free memory*/
+		/* Delete all JSON objects to free memory */
 		cJSON_Delete(onvm_json_root);
-		cJSON_Delete(onvm_json_port_stats_obj);
-		cJSON_Delete(onvm_json_nf_stats_obj);
 		cJSON_Delete(onvm_json_events_arr);
-		cJSON_DeleteArray(onvm_json_port_stats, RTE_MAX_ETHPORTS);
-		cJSON_DeleteArray(onvm_json_nf_stats, MAX_NFS);
         }
 }
 
@@ -266,16 +256,6 @@ onvm_stats_add_event(const char *msg, struct onvm_nf_info *nf_info) {
 
 
 /****************************Internal functions*******************************/
-
-static void
-cJSON_DeleteArray(cJSON **arr, unsigned length) {
-	if (stats_destination == ONVM_STATS_WEB && arr != NULL && length != 0) {
-		unsigned i;
-		for(i = 0; i < length; i++) {
-			cJSON_Delete(arr[i]);
-		}
-	}
-}
 
 static void
 onvm_stats_display_ports(unsigned difftime, uint8_t verbosity_level) {

--- a/onvm/onvm_mgr/onvm_stats.c
+++ b/onvm/onvm_mgr/onvm_stats.c
@@ -57,6 +57,11 @@
 
 /************************Internal Functions Prototypes************************/
 
+/*
+ * Function helps delete lists of cJSON objects
+ */
+static void
+cJSON_DeleteArray(cJSON **arr, unsigned length);
 
 /*
  * Function displaying statistics for all ports
@@ -171,8 +176,16 @@ onvm_stats_cleanup(void) {
                 fclose(stats_out);
                 fclose(json_stats_out);
                 fclose(json_events_out);
+		/* Delete all JSON objects to free memory*/
+		cJSON_Delete(onvm_json_root);
+		cJSON_Delete(onvm_json_port_stats_obj);
+		cJSON_Delete(onvm_json_nf_stats_obj);
+		cJSON_Delete(onvm_json_events_arr);
+		cJSON_DeleteArray(onvm_json_port_stats, RTE_MAX_ETHPORTS);
+		cJSON_DeleteArray(onvm_json_nf_stats, MAX_NFS);
         }
 }
+
 
 void
 onvm_stats_display_all(unsigned difftime, uint8_t verbosity_level) {
@@ -254,6 +267,15 @@ onvm_stats_add_event(const char *msg, struct onvm_nf_info *nf_info) {
 
 /****************************Internal functions*******************************/
 
+static void
+cJSON_DeleteArray(cJSON **arr, unsigned length) {
+	if (stats_destination == ONVM_STATS_WEB && arr != NULL && length != 0) {
+		unsigned i;
+		for(i = 0; i < length; i++) {
+			cJSON_Delete(arr[i]);
+		}
+	}
+}
 
 static void
 onvm_stats_display_ports(unsigned difftime, uint8_t verbosity_level) {


### PR DESCRIPTION
Fixes onvm web memory leak by deleting the cJSON objects upon exiting

## Summary: 
In order to avoid data leaks after running the web console of ONVM, cJSON objects initialized in onvm_stats.c needed to be freed. cJSON objects are created and destroyed with helper functions from /onvm/lib/cJSON.c. The code in onvm_stats_cleanup fixes this bug. 

**Usage:**

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | Fixes #283
| Breaking API changes     | 
| Internal API changes     | 
| Usability improvements   |  
| Bug fixes                | 👍
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 👍


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [x] PR is ready for review

## Test Plan:
Tested on a Wisconsin c220g2 cloudlab node with Ubuntu 14.04.1 
Run using onvm web as the output -  onvm_stats_cleanup code doesn't run on the standard onvm stdout

| Speed Tester   | Packets/Sec  |
|---|---|
| 1 NF  | 42097232  |

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
- Sanity checks, assigned to @koolzz @dennisafa 
  - Run make in /onvm and /examples directories
  - Test new functionality or bug fix from the pr (if needed)
- Code style, assigned to @koolzz @dennisafa 
  - Run linter
  - Check everything style related
- Code design, assigned to @koolzz @dennisafa 
  - Check for memory leaks
  - Check that code is reusable
  - Code is clean, functions are concise
  - Verify that edge cases properly handled
- Performance, assigned to @koolzz @dennisafa 
  - Run onvm with the web output (``` <onvm go args> -s web ```)
  - Run Speed Tester NF, report performance.
- Documentation, assigned to @dennisafa 
  - Check if the new changes are well documented, in both code and READMEs