### PR TITLE
Update install script huge page setup

### DIFF
--- a/scripts/dpdk_helper_scripts.sh
+++ b/scripts/dpdk_helper_scripts.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+HUGEPGSZ=`cat /proc/meminfo  | grep Hugepagesize | cut -d : -f 2 | tr -d ' '`
+
+#
+# Unloads igb_uio.ko.
+#
+remove_igb_uio_module()
+{
+    echo "Unloading any existing DPDK UIO module"
+    /sbin/lsmod | grep -s igb_uio > /dev/null
+    if [ $? -eq 0 ] ; then
+        sudo /sbin/rmmod igb_uio
+    fi
+}
+
+#
+# Creates hugepage filesystem.
+#
+create_mnt_huge()
+{
+    echo "Creating /mnt/huge and mounting as hugetlbfs"
+    sudo mkdir -p /mnt/huge
+
+    grep -s '/mnt/huge' /proc/mounts > /dev/null
+    if [ $? -ne 0 ] ; then
+        sudo mount -t hugetlbfs nodev /mnt/huge
+    fi
+}
+
+#
+# Removes hugepage filesystem.
+#
+remove_mnt_huge()
+{
+    echo "Unmounting /mnt/huge and removing directory"
+    grep -s '/mnt/huge' /proc/mountsi > /dev/null
+    if [ $? -eq 0 ] ; then
+        sudo umount /mnt/huge
+    fi
+
+    if [ -d /mnt/huge ] ; then
+        sudo rm -R /mnt/huge
+    fi
+}
+
+#
+# Removes all reserved hugepages.
+#
+clear_huge_pages()
+{
+    echo > .echo_tmp
+    for d in /sys/devices/system/node/node? ; do
+        echo "echo 0 > $d/hugepages/hugepages-${HUGEPGSZ}/nr_hugepages" >> .echo_tmp
+    done
+    echo "Removing currently reserved hugepages"
+    sudo sh .echo_tmp
+    rm -f .echo_tmp
+
+    remove_mnt_huge
+}
+
+#
+# Creates hugepages on specific NUMA nodes.
+#
+set_numa_pages()
+{
+    echo "Setting up hugepages"
+    sleep 1
+    set +e
+
+    clear_huge_pages
+
+    hp_count="${ONVM_NUM_HUGEPAGES:-1024}"
+
+    echo > .echo_tmp
+    for d in /sys/devices/system/node/node? ; do
+        node=$(basename $d)
+        echo "echo $hp_count > $d/hugepages/hugepages-${HUGEPGSZ}/nr_hugepages" >> .echo_tmp
+    done
+    echo "Reserving hugepages"
+    sudo sh .echo_tmp
+    rm -f .echo_tmp
+
+    create_mnt_huge
+
+    hp_free=$(cat /proc/meminfo | grep HugePages_Free | awk '{print $2}')
+    if [ $hp_free == "0" ]; then
+        echo "Coudn't set up huge pages. Did you try turning it off and on again?"
+        exit 1
+    else
+        echo "Huge pages successfully configured"
+    fi
+
+    set -e
+}

--- a/scripts/dpdk_helper_scripts.sh
+++ b/scripts/dpdk_helper_scripts.sh
@@ -34,7 +34,7 @@ create_mnt_huge()
 remove_mnt_huge()
 {
     echo "Unmounting /mnt/huge and removing directory"
-    grep -s '/mnt/huge' /proc/mountsi > /dev/null
+    grep -s '/mnt/huge' /proc/mounts > /dev/null
     if [ $? -eq 0 ] ; then
         sudo umount /mnt/huge
     fi

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -73,20 +73,15 @@ if [ -z "$ONVM_HOME" ]; then
     exit 1
 fi
 
+# Source DPDK helper functions
+. $ONVM_HOME/scripts/dpdk_helper_scripts.sh
+
 # Disable ASLR
 sudo sh -c "echo 0 > /proc/sys/kernel/randomize_va_space"
 
 # Setup/Check for free HugePages if the user wants to
 if [ -z "$ONVM_SKIP_HUGEPAGES" ]; then
-	hp_size=$(cat /proc/meminfo | grep Hugepagesize | awk '{print $2}')
-	hp_count="${ONVM_NUM_HUGEPAGES:-1024}"
-
-	sudo sh -c "echo $hp_count > /sys/devices/system/node/node0/hugepages/hugepages-${hp_size}kB/nr_hugepages"
-	hp_free=$(cat /proc/meminfo | grep HugePages_Free | awk '{print $2}')
-	if [ $hp_free == "0" ]; then
-    	echo "No free huge pages. Did you try turning it off and on again?"
-    	exit 1
-	fi
+    set_numa_pages $hp_count
 fi
 
 # Verify sudo access


### PR DESCRIPTION
Uses the same functions that dpdk uses to set up huge pages, with minor adjustments to onvm.

<!-- Add detailed description and provide running instructions -->
## Summary:
- Adds better huge page setup to the `install.sh` and `setup_environment.sh` scripts.
   - Properly mounts hp, which makes our `setup_environment.sh` equivalent to using the `dpdk-setup.sh` script.
   - Sets memory for all NUMA nodes, instead of just `node0` (this could actually resolve some hugepage bugs)
- Removes the old igb_uio module on `install.sh`

**Usage:**
Install onvm, use the setup_script.

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          |  Fixes #83
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  :100: 
| Bug fixes                | :+1: 
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [x] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:
Run both, be sure it doesn't break. Check if it actually resolves #83. 

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
Assigned to @rskennedy 