### PR TITLE
Ensure system is up-to-date in installation guide

### DIFF
--- a/docs/Install.md
+++ b/docs/Install.md
@@ -29,7 +29,7 @@ Check System
    ```sh
    sudo apt-get install libnuma-dev
    ```
-   Verify that your system is up to date before installing this package:
+   If installing libnuma-dev fails, your system may not be up to date. To fix this, run:
    ```sh
    sudo apt-get update
    ```

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -21,13 +21,17 @@ Check System
     ```sh
     sudo apt-get install build-essential linux-headers-$(uname -r) git
     ```
-4. Assure your kernel suppors uio
+4. Assure your kernel supports uio
     ```sh
     locate uio
     ```
 5. Install libnuma
    ```sh
    sudo apt-get install libnuma-dev
+   ```
+   Verify that your system is up to date before installing this package:
+   ```sh
+   sudo apt-get update
    ```
 
 Setup Repositories


### PR DESCRIPTION
Installing libnuma-dev may not work if your system is not up-to-date. A user may need to update before running `sudo apt-get libnuma-dev`
