### PR TITLE
Reuse NF instance IDs

### DIFF
--- a/onvm/onvm_mgr/main.c
+++ b/onvm/onvm_mgr/main.c
@@ -252,11 +252,9 @@ main(int argc, char *argv[]) {
         unsigned i;
 
         /* initialise the system */
-
-        /* Reserve ID 0 for internal manager things */
-        next_instance_id = 1;
         if (init(argc, argv) < 0)
                 return -1;
+
         RTE_LOG(INFO, APP, "Finished Process Init.\n");
 
         /* clear statistics */

--- a/onvm/onvm_mgr/onvm_mgr.h
+++ b/onvm/onvm_mgr/onvm_mgr.h
@@ -79,9 +79,4 @@
 #define TO_PORT 0
 #define TO_NF 1
 
-/***************************Shared global variables***************************/
-
-/* ID to be assigned to the next NF that starts */
-extern uint16_t next_instance_id;
-
 #endif  // _ONVM_MGR_H_

--- a/onvm/onvm_mgr/onvm_nf.c
+++ b/onvm/onvm_mgr/onvm_nf.c
@@ -93,11 +93,10 @@ onvm_nf_next_instance_id(void) {
         struct onvm_nf *nf;
         uint16_t instance_id;
 
-        //printf("instanct = %d, next_inst = %d\n", instance_id, next_instance_id);
         if (num_nfs >= MAX_NFS)
                 return MAX_NFS;
 
-        /* Do a first pass for nf_ids bigger than current next_instance_id */
+        /* Do a first pass for NF IDs bigger than current next_instance_id */
         while (next_instance_id < MAX_NFS) {
                 instance_id = next_instance_id++;
                 /* Check if this id is occupied by another NF */
@@ -198,7 +197,7 @@ onvm_nf_start(struct onvm_nf_info *nf_info) {
         // assume user is smart enough to avoid duplicates
         uint16_t nf_id = nf_info->instance_id == (uint16_t)NF_NO_ID ? onvm_nf_next_instance_id() : nf_info->instance_id;
 
-        if (nf_id == 0 || nf_id >= MAX_NFS) {
+        if (nf_id >= MAX_NFS) {
                 // There are no more available IDs for this NF
                 nf_info->status = NF_NO_IDS;
                 return 1;

--- a/onvm/onvm_mgr/onvm_nf.c
+++ b/onvm/onvm_mgr/onvm_nf.c
@@ -50,7 +50,9 @@
 #include "onvm_mgr.h"
 #include "onvm_stats.h"
 
-uint16_t next_instance_id = 0;
+/* ID 0 is reserved */
+uint16_t next_instance_id = 1;
+uint16_t starting_instance_id = 1;
 
 /************************Internal functions prototypes************************/
 
@@ -89,16 +91,36 @@ onvm_nf_stop(struct onvm_nf_info *nf_info);
 uint16_t
 onvm_nf_next_instance_id(void) {
         struct onvm_nf *nf;
-        uint16_t instance_id = MAX_NFS;
+        uint16_t instance_id;
 
+        //printf("instanct = %d, next_inst = %d\n", instance_id, next_instance_id);
+        if (num_nfs >= MAX_NFS)
+                return MAX_NFS;
+
+        /* Do a first pass for nf_ids bigger than current next_instance_id */
         while (next_instance_id < MAX_NFS) {
                 instance_id = next_instance_id++;
+                /* Check if this id is occupied by another NF */
                 nf = &nfs[instance_id];
                 if (!onvm_nf_is_valid(nf))
-                        break;
+                        return instance_id;
         }
 
-        return instance_id;
+        /* Reset to starting position */
+        next_instance_id = starting_instance_id;
+
+        /* Do a second pass for other NF IDs */
+        while (next_instance_id < MAX_NFS) {
+                instance_id = next_instance_id++;
+                /* Check if this id is occupied by another NF */
+                nf = &nfs[instance_id];
+                if (!onvm_nf_is_valid(nf))
+                        return instance_id;
+        }
+
+        /* This should never happen, means our num_nfs counter is wrong */
+        RTE_LOG(ERR, APP, "Tried to allocated a next instance ID but num_nfs is corrupted\n");
+        return MAX_NFS;
 }
 
 void
@@ -176,7 +198,7 @@ onvm_nf_start(struct onvm_nf_info *nf_info) {
         // assume user is smart enough to avoid duplicates
         uint16_t nf_id = nf_info->instance_id == (uint16_t)NF_NO_ID ? onvm_nf_next_instance_id() : nf_info->instance_id;
 
-        if (nf_id >= MAX_NFS) {
+        if (nf_id == 0 || nf_id >= MAX_NFS) {
                 // There are no more available IDs for this NF
                 nf_info->status = NF_NO_IDS;
                 return 1;

--- a/onvm/onvm_mgr/onvm_nf.h
+++ b/onvm/onvm_mgr/onvm_nf.h
@@ -52,8 +52,6 @@
 
 #include "onvm_threading.h"
 
-extern uint16_t next_instance_id;
-
 /********************************Interfaces***********************************/
 
 /*

--- a/onvm/onvm_nflib/onvm_common.h
+++ b/onvm/onvm_nflib/onvm_common.h
@@ -51,7 +51,7 @@
 #include "onvm_msg_common.h"
 
 #define ONVM_MAX_CHAIN_LENGTH 4  // the maximum chain length
-#define MAX_NFS 128              // total number of NFs allowed
+#define MAX_NFS 128              // total number of concurrent NFs allowed (-1 because ID 0 is reserved)
 #define MAX_SERVICES 32          // total number of unique services allowed
 #define MAX_NFS_PER_SERVICE 32   // max number of NFs per service.
 


### PR DESCRIPTION
Instead of stopping when we reach MAX_NFS, wrap back to the initial instance ID starting value.

<!-- Add detailed description and provide running instructions -->
## Summary:
Reuse instance IDs of old NFs that have terminated. 
I've initially implemented an inline function for the while loop so we don't use the code twice, but I revised this as I think the 2 loops with comments just look cleaner.

**Usage:**
I tested with decreasing MAX_NFS number to 4, seems to work didn't test all the small details yet.

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  🎉 
| Bug fixes                |
| New functionality        | 👍 
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [x] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:
Try to break this. 

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
TBA