### PR TITLE
Packet number bug fix

### DIFF
--- a/docs/Install.md
+++ b/docs/Install.md
@@ -222,7 +222,7 @@ Troubleshooting
 
     You can check the current status of NIC port bindings with
 
-    `sudo ./tools/dpdk_nic_bind.py  --status`
+    `sudo ./usertools/dpdk-devbind.py  --status`
 
     Output similar to below will show what driver each NIC port is bound to.
 
@@ -245,11 +245,11 @@ Troubleshooting
 
     `sudo ifconfig eth2 down`
 
-    Rerun the status command, `./tools/dpdk_nic_bind.py --status`, to see that it is not active anymore.  Once that is done, proceed to bind the NIC port to the DPDK Kenrel module:
+    Rerun the status command, `./usertools/dpdk-devbind.py --status`, to see that it is not active anymore.  Once that is done, proceed to bind the NIC port to the DPDK Kenrel module:
 
-    `sudo ./tools/dpdk_nic_bind.py -b igb_uio 07:00.0`
+    `sudo ./usertools/dpdk-devbind.py -b igb_uio 07:00.0`
 
-    Check the status again, `./tools/dpdk_nic_bind.py --status`, and assure the output is similar to our example below:
+    Check the status again, `./usertools/dpdk-devbind.py --status`, and assure the output is similar to our example below:
 
     ```
     Network devices using DPDK-compatible driver
@@ -268,7 +268,7 @@ Troubleshooting
 
 5. **Poor Performance**
 
-If you are not getting the expected level of performance, try these:
+    If you are not getting the expected level of performance, try these:
 
- - Ensure the manager and NFs are all given different core numbers. Use cores on the same sockets for best results.
- - If running a long chain of NFs, ensure that there are sufficient packets to keep the chain busy. If using locally generated packets (i.e., the Speed Tester NFs) then use the `-c` flag to increase the number of packets created. For best results, run multiple Speed Tester NFs, or use an external generator like pktgen.
+	 - Ensure the manager and NFs are all given different core numbers. Use cores on the same sockets for best results.
+	 - If running a long chain of NFs, ensure that there are sufficient packets to keep the chain busy. If using locally generated packets (i.e., the Speed Tester NFs) then use the `-c` flag to increase the number of packets created. For best results, run multiple Speed Tester NFs, or use an external generator like pktgen.

--- a/examples/speed_tester/speed_tester.c
+++ b/examples/speed_tester/speed_tester.c
@@ -452,9 +452,6 @@ nf_setup(struct onvm_nf_info *nf_info) {
                                 break;
                         }
 
-                        /*new packet generated successfully*/
-                        pkts_generated++;
-
                         /*set up ether header and set new packet size*/
                         ehdr = (struct ether_hdr *)rte_pktmbuf_append(pkt, packet_size);
 
@@ -480,7 +477,10 @@ nf_setup(struct onvm_nf_info *nf_info) {
                                 uint64_t *ts = (uint64_t *)rte_pktmbuf_append(pkt, sizeof(uint64_t));
                                 *ts = 0;
                         }
+
+                        /* New packet generated successfully */
                         pkts[i] = pkt;
+                        pkts_generated++;
                 }
                 onvm_nflib_return_pkt_bulk(nf_info, pkts, pkts_generated);
 #ifdef LIBPCAP

--- a/examples/speed_tester/speed_tester.c
+++ b/examples/speed_tester/speed_tester.c
@@ -487,7 +487,7 @@ nf_setup(struct onvm_nf_info *nf_info) {
         }
 #endif
         /* Exit if packets were unexpectedly not created */
-        if(pkts_generated == 0 && packet_number > 0)
+        if (pkts_generated == 0 && packet_number > 0)
                 rte_exit(EXIT_FAILURE, "Failed to create packets\n");
 
         packet_number = pkts_generated;

--- a/examples/speed_tester/speed_tester.c
+++ b/examples/speed_tester/speed_tester.c
@@ -375,7 +375,7 @@ run_advanced_rings(struct onvm_nf_info *nf_info) {
 void
 nf_setup(struct onvm_nf_info *nf_info) {
         uint32_t i;
-        uint32_t pkts_generated = 0;
+        uint32_t pkts_generated;
         struct rte_mempool *pktmbuf_pool;
 
         pktmbuf_pool = rte_mempool_lookup(PKTMBUF_POOL_NAME);
@@ -404,6 +404,7 @@ nf_setup(struct onvm_nf_info *nf_info) {
                 struct rte_mbuf *pkts[packet_number];
 
                 i = 0;
+                pkts_generated = 0;
 
                 while (((packet = pcap_next(pcap, &header)) != NULL) && (i < packet_number)) {
                         struct onvm_pkt_meta *pmeta;
@@ -428,15 +429,15 @@ nf_setup(struct onvm_nf_info *nf_info) {
                         pkt->hash.rss = onvm_softrss(&key);
 
                         /* Add packet to batch, and update counter */
-                        pkts[i] = pkt;
+                        pkts[i++] = pkt;
                         pkts_generated++;
-                        i++;
                 }
                 onvm_nflib_return_pkt_bulk(nf_info, pkts, pkts_generated);
         } else {
 #endif
                 /*  use default number of initial packets if -c has not been used */
                 packet_number = (use_custom_pkt_count ? packet_number : DEFAULT_PKT_NUM);
+                pkts_generated = 0;
                 struct rte_mbuf *pkts[packet_number];
 
                 printf("Creating %u packets to send to %u\n", packet_number, destination);

--- a/examples/speed_tester/speed_tester.c
+++ b/examples/speed_tester/speed_tester.c
@@ -486,6 +486,10 @@ nf_setup(struct onvm_nf_info *nf_info) {
 #ifdef LIBPCAP
         }
 #endif
+        /* Exit if packets were unexpectedly not created */
+        if(pkts_generated == 0 && packet_number > 0)
+                rte_exit(EXIT_FAILURE, "Failed to create packets\n");
+
         packet_number = pkts_generated;
 }
 

--- a/examples/speed_tester/speed_tester.c
+++ b/examples/speed_tester/speed_tester.c
@@ -378,6 +378,7 @@ nf_setup(struct onvm_nf_info *nf_info) {
         uint32_t pkts_generated;
         struct rte_mempool *pktmbuf_pool;
 
+        pkts_generated = 0;
         pktmbuf_pool = rte_mempool_lookup(PKTMBUF_POOL_NAME);
         if (pktmbuf_pool == NULL) {
                 onvm_nflib_stop(nf_info);
@@ -404,7 +405,6 @@ nf_setup(struct onvm_nf_info *nf_info) {
                 struct rte_mbuf *pkts[packet_number];
 
                 i = 0;
-                pkts_generated = 0;
 
                 while (((packet = pcap_next(pcap, &header)) != NULL) && (i < packet_number)) {
                         struct onvm_pkt_meta *pmeta;
@@ -437,7 +437,6 @@ nf_setup(struct onvm_nf_info *nf_info) {
 #endif
                 /*  use default number of initial packets if -c has not been used */
                 packet_number = (use_custom_pkt_count ? packet_number : DEFAULT_PKT_NUM);
-                pkts_generated = 0;
                 struct rte_mbuf *pkts[packet_number];
 
                 printf("Creating %u packets to send to %u\n", packet_number, destination);


### PR DESCRIPTION
Fixes a manager segmentation fault due to packet initialization.

<!-- Add detailed description and provide running instructions -->
## Summary:
When running multiple `speed_tester` NFs at once, shutting down and restarting, `rte_pktmbuf_alloc` sometimes cannot allocate all the packets. This would cause an issue with the number of packets in the following statement: 
```c
onvm_nflib_return_pkt_bulk(nf_info, pkts, pkts_generated);
``` 
The variable `pkts` had a length of `packet_number` (static uint32_t), but if we couldn't allocate the packet, we continue to the next try in the loop (`while` for LIBPCAP & `for` for `-c packet_num`). This pr fixes this by making a temporary counter to see how many packets were actually initialized. 

**Usage:**
Test by starting the manager with two NFs as such `./go.sh 1 -d 1 -c 16000` or `./go.sh 1 -d 1 -o pcap/pcap_file_here.pcap`. Then after both speed_testers are running on same destination, restart one going to another destination (`./go.sh 2 -d 2 -c 16000`). The manager should be able to handle this now. 

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                | 👍
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [x] PR is ready for review
 - [x] Test without the fix, and make sure the same process doesn't break with this PR 

## Review: 
- Sanity checks, assigned to @koolzz  @dennisafa 
  - Run make in /onvm and /examples directories
  - Code style, assigned to @koolzz  @dennisafa 

- Run linter
  - Check everything style related
  - Code design, assigned to @koolzz  @dennisafa 

- Check for memory leaks
  - Check that code is reusable
  - Code is clean, functions are concise
  - Verify that edge cases properly handled

- Performance, assigned to @koolzz  @dennisafa 
  - Run Speed Tester NF, report performance.

- Documentation, assigned to @koolzz  @dennisafa 
  - Check if the new changes are well documented, in both code and READMEs
