### PR TITLE
Fix NF Tag memory allocation

### DIFF
--- a/examples/speed_tester/speed_tester.c
+++ b/examples/speed_tester/speed_tester.c
@@ -67,7 +67,7 @@
 #include "onvm_nflib.h"
 #include "onvm_pkt_helper.h"
 
-#define NF_TAG "speed"
+#define NF_TAG "speed_tester"
 
 #define PKTMBUF_POOL_NAME "MProc_pktmbuf_pool"
 #define PKT_READ_SIZE ((uint16_t)32)

--- a/onvm/onvm_mgr/onvm_nf.c
+++ b/onvm/onvm_mgr/onvm_nf.c
@@ -247,6 +247,12 @@ onvm_nf_stop(struct onvm_nf_info *nf_info) {
         service_id = nf_info->service_id;
         nf_status = nf_info->status;
 
+        /* Cleanup the allocated tag */
+        if (nf_info->tag) {
+                rte_free(nf_info->tag);
+                nf_info->tag = NULL;
+        }
+
         /* Cleanup should only happen if NF was starting or running */
         if (nf_status != NF_STARTING && nf_status != NF_RUNNING && nf_status != NF_PAUSED)
                 return 1;

--- a/onvm/onvm_nflib/onvm_common.h
+++ b/onvm/onvm_nflib/onvm_common.h
@@ -69,7 +69,8 @@
 #define MANUAL_CORE_ASSIGNMENT_BIT 0
 #define SHARE_CORE_BIT 1
 
-// extern uint8_t rss_symmetric_key[40];
+/* Maximum length of NF_TAG including the \0 */
+#define TAG_SIZE 15
 
 // flag operations that should be used on onvm_pkt_meta
 #define ONVM_CHECK_BIT(flags, n) !!((flags) & (1 << (n)))

--- a/onvm/onvm_nflib/onvm_common.h
+++ b/onvm/onvm_nflib/onvm_common.h
@@ -191,7 +191,7 @@ struct onvm_nf_scale_info {
         uint16_t service_id;
         uint16_t core;
         uint8_t flags;
-        const char *tag;
+        char *tag;
         void *data;
         setup_func setup_func;
         pkt_handler_func pkt_func;
@@ -257,7 +257,7 @@ struct onvm_nf_info {
         uint16_t core;
         uint8_t flags;
         uint8_t status;
-        const char *tag;
+        char *tag;
         /* If set NF will stop after time reaches time_to_live */
         uint16_t time_to_live;
         /* If set NF will stop after pkts TX reach pkt_limit */

--- a/onvm/onvm_nflib/onvm_nflib.c
+++ b/onvm/onvm_nflib/onvm_nflib.c
@@ -890,6 +890,7 @@ static struct onvm_nf_info *
 onvm_nflib_info_init(const char *tag) {
         void *mempool_data;
         struct onvm_nf_info *info;
+        char *allocated_tag;
 
         if (rte_mempool_get(nf_info_mp, &mempool_data) < 0) {
                 rte_exit(EXIT_FAILURE, "Failed to get nf info memory\n");
@@ -904,7 +905,12 @@ onvm_nflib_info_init(const char *tag) {
         info->core = rte_lcore_id();
         info->flags = 0;
         info->status = NF_WAITING_FOR_ID;
-        info->tag = tag;
+
+        /* Allocate memory for the tag so that onvm_mgr can access it */
+        allocated_tag = rte_malloc("nf_tag", TAG_SIZE, 0);
+        strncpy(allocated_tag, tag, TAG_SIZE);
+        info->tag = allocated_tag;
+
         /* TTL and packet limit disabled by default */
         info->time_to_live = 0;
         info->pkt_limit = 0;

--- a/onvm/onvm_nflib/onvm_nflib.c
+++ b/onvm/onvm_nflib/onvm_nflib.c
@@ -890,7 +890,6 @@ static struct onvm_nf_info *
 onvm_nflib_info_init(const char *tag) {
         void *mempool_data;
         struct onvm_nf_info *info;
-        char *allocated_tag;
 
         if (rte_mempool_get(nf_info_mp, &mempool_data) < 0) {
                 rte_exit(EXIT_FAILURE, "Failed to get nf info memory\n");
@@ -907,9 +906,8 @@ onvm_nflib_info_init(const char *tag) {
         info->status = NF_WAITING_FOR_ID;
 
         /* Allocate memory for the tag so that onvm_mgr can access it */
-        allocated_tag = rte_malloc("nf_tag", TAG_SIZE, 0);
-        strncpy(allocated_tag, tag, TAG_SIZE);
-        info->tag = allocated_tag;
+        info->tag = rte_malloc("nf_tag", TAG_SIZE, 0);
+        strncpy(info->tag, tag, TAG_SIZE);
 
         /* TTL and packet limit disabled by default */
         info->time_to_live = 0;


### PR DESCRIPTION
Fix NF Tag to properly display it in stats later

<!-- Add detailed description and provide running instructions -->
## Summary:
Before we were passing a `const char *` for the nf tag and the pointer was local NF stack memory, which was clearly not accessible by the onvm_mgr. This pr fixes this issue by placing nf_tag on the heap and defining a max length of the provided nf tag. 

This has no breaking changes as its all internal logic.

**With this PR we have everything to rework stdout stats with both a tag and the core info(lets discuss formatting details in the meeting). Also, @kevindweb you gotta handle webstats, every NF can now be properly labeled (Speed Tester 1) instead of (NF 1) 😉**

**Usage:**
Tested by printing `%s` with tag from the onvm_mgr stats output.

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                | 👍 
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [ ] Might want to update all the current tags?
 - [ ] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:
Test functionality, makes sure onvm no break

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
TBA