### PR TITLE
Fix memory leaks on NF shutdown

### DIFF
--- a/onvm/onvm_nflib/onvm_nflib.c
+++ b/onvm/onvm_nflib/onvm_nflib.c
@@ -295,6 +295,7 @@ onvm_nflib_lookup_shared_structs(void) {
 static int
 onvm_nflib_start_nf(struct onvm_nf_info *nf_info) {
         struct onvm_nf_msg *startup_msg;
+        struct onvm_nf *nf;
 
         /* Put this NF's info struct onto queue for manager to process startup */
         if (rte_mempool_get(nf_msg_pool, (void **)(&startup_msg)) != 0) {
@@ -350,14 +351,23 @@ onvm_nflib_start_nf(struct onvm_nf_info *nf_info) {
                 rte_exit(EXIT_FAILURE, "Error occurred during manager initialization\n");
         }
 
+        nf = &nfs[nf_info->instance_id];
+
         /* Set mode to UNKNOWN, to be determined later */
-        nfs[nf_info->instance_id].nf_mode = NF_MODE_UNKNOWN;
+        nf->nf_mode = NF_MODE_UNKNOWN;
 
         /* Initialize empty NF's tx manager */
-        onvm_nflib_nf_tx_mgr_init(&nfs[nf_info->instance_id]);
+        onvm_nflib_nf_tx_mgr_init(nf);
 
         /* Set the parent id to none */
-        nfs[nf_info->instance_id].parent = 0;
+        nf->parent = 0;
+
+        /* In case this instance_id is reused, clear all function pointers */
+        nf->nf_pkt_function = NULL;
+        nf->nf_callback_function = NULL;
+        nf->nf_advanced_rings_function = NULL;
+        nf->nf_setup_function = NULL;
+        nf->nf_handle_msg_function = NULL;
 
         RTE_LOG(INFO, APP, "Using Instance ID %d\n", nf_info->instance_id);
         RTE_LOG(INFO, APP, "Using Service ID %d\n", nf_info->service_id);
@@ -450,6 +460,7 @@ onvm_nflib_init(int argc, char *argv[], const char *nf_tag, struct onvm_nf_info 
 int
 onvm_nflib_run_callback(struct onvm_nf_info *info, pkt_handler_func handler, callback_handler_func callback) {
         struct onvm_nf *nf;
+        int ret;
 
         /* Listen for ^C and docker stop so we can exit gracefully */
         signal(SIGINT, onvm_nflib_handle_signal);
@@ -468,8 +479,12 @@ onvm_nflib_run_callback(struct onvm_nf_info *info, pkt_handler_func handler, cal
         nf->nf_callback_function = callback;
 
         pthread_t main_loop_thread;
-        pthread_create(&main_loop_thread, NULL, onvm_nflib_thread_main_loop, (void *)nf);
-        pthread_join(main_loop_thread, NULL);
+        if ((ret = pthread_create(&main_loop_thread, NULL, onvm_nflib_thread_main_loop, (void *)nf)) < 0) {
+                rte_exit(EXIT_FAILURE, "Failed to spawn main loop thread, error %d", ret);
+        }
+        if ((ret = pthread_join(main_loop_thread, NULL)) < 0) {
+                rte_exit(EXIT_FAILURE, "Failed to join with main loop thread, error %d", ret);
+        }
 
         return 0;
 }
@@ -705,13 +720,13 @@ onvm_nflib_scale(struct onvm_nf_scale_info *scale_info) {
 
         ret = pthread_create(&app_thread, NULL, &onvm_nflib_start_child, scale_info);
         if (ret < 0) {
-                RTE_LOG(INFO, APP, "Failed to create thread\n");
+                RTE_LOG(INFO, APP, "Failed to create child thread\n");
                 return -1;
         }
 
         ret = pthread_detach(app_thread);
         if (ret < 0) {
-                RTE_LOG(INFO, APP, "Failed to detach thread\n");
+                RTE_LOG(INFO, APP, "Failed to detach child thread\n");
                 return -1;
         }
 
@@ -1008,13 +1023,31 @@ onvm_nflib_handle_signal(int sig) {
 
 static void
 onvm_nflib_cleanup(struct onvm_nf_info *nf_info) {
+        struct onvm_nf *nf;
         if (nf_info == NULL) {
                 return;
         }
 
+        nf = &nfs[nf_info->instance_id];
+
+        /* Cleanup state data */
         if (nf_info->data != NULL) {
                 rte_free(nf_info->data);
                 nf_info->data = NULL;
+        }
+
+        /* Cleanup for the nf_tx_mgr pointers */
+        if (nf->nf_tx_mgr->to_tx_buf != NULL) {
+                free(nf->nf_tx_mgr->to_tx_buf);
+                nf->nf_tx_mgr->to_tx_buf = NULL;
+        }
+        if (nf->nf_tx_mgr->nf_rx_bufs != NULL) {
+                free(nf->nf_tx_mgr->nf_rx_bufs);
+                nf->nf_tx_mgr->nf_rx_bufs = NULL;
+        }
+        if (nf->nf_tx_mgr != NULL) {
+                free(nf->nf_tx_mgr);
+                nf->nf_tx_mgr = NULL;
         }
 
         struct onvm_nf_msg *shutdown_msg;


### PR DESCRIPTION
Fix onvm_nf struct cleanup & memory leaks.

<!-- Add detailed description and provide running instructions -->
## Summary:
 - When looking at reusing instance IDs I've hit some segfaults due to the `onvm_nf` struct having some old dangling pointers, this pr fixes that by NULLing them out.
 - Also free few pointers that we were not freeing before 
 - Add minor code cleanup/error checking

**Usage:**
Run NFs as usual

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                | 👍 
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: Merge after shared CPU, it might have some other stuff that needs cleanup

**TODO before merging :**
 - [ ] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:
Check that nothing breaks. 

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
@dennisafa @kevindweb you know the drill (I'll ping you again when ready for full review)