### PR TITLE
Check if ONVM_HOME environment variable is set

### DIFF
--- a/onvm/onvm_nflib/Makefile
+++ b/onvm/onvm_nflib/Makefile
@@ -40,6 +40,10 @@ ifeq ($(RTE_SDK),)
 $(error "Please define RTE_SDK environment variable")
 endif
 
+ifeq ($(ONVM_HOME),)
+$(error "Please define the ONVM_HOME environment variable")
+endif
+
 # Default target, can be overriden by command line or environment
 include $(RTE_SDK)/mk/rte.vars.mk
 


### PR DESCRIPTION
Check to see if the necessary env variable ONVM_HOME is set (resolves #61 )

<!-- Add detailed description and provide running instructions -->
## Summary:
The Makefile in onvm_nflib required the env variable ONVM_HOME, this checks to see if it is set by the user or not before proceeding. 

**Usage:**

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  X
| Bug fixes                |
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [x] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:
Test by unsetting ONVM_HOME and running make, verify an exit. Set and Make again to check if it runs.

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
I think this is a fairly quick one to test @koolzz @kevindweb 

* Sanity checks, assigned to @koolzz @kevindweb
  * Run make in /onvm and /examples directories
  * Test new functionality or bug fix from the pr (if needed)

* Code style, assigned to @koolzz @kevindweb
  * Run linter
  * Check everything style related

* Code design, assigned to @koolzz @kevindweb

  * Check for memory leaks
  * Check that code is reusable
  * Code is clean, functions are concise
  * Verify that edge cases properly handled

* Documentation, assigned to @koolzz @kevindweb
  * Check if the new changes are well documented, in both code and READMEs
