### PR TITLE
Broken style guide fixes

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -16,6 +16,6 @@ To contribute to OpenNetVM, please follow these steps:
       - `git pull --rebase upstream develop`
   8. Please fill out the pull request template as best as possible and be very detailed/thorough.
 
-[style]: style/styleguide.md
+[style]: ../style/styleguide.md
 [gitflow]: https://guides.github.com/introduction/flow/
 [commitguide]: https://chris.beams.io/posts/git-commit/

--- a/style/styleguide.md
+++ b/style/styleguide.md
@@ -214,7 +214,7 @@ We use git to track code changes. Learn how to use it.
 # More Resources
 The contents of this guide are largely stolen from the [Composite Style Guide](https://github.com/gparmer/Composite/blob/master/doc/style_guide/composite_coding_style.pdf?raw=true). Where not discussed here, follow the Composite rules.
 
-[Google's C++ Style Guide](http://google-styleguide.googlecode.com/svn/trunk/cppguide.html#Header_Files) also provides many reasonable style choices, and is used by many different companies. Where not discussed here or in the Composite guide, follow Google's.
+[Google's C++ Style Guide](https://google.github.io/styleguide/cppguide.html) also provides many reasonable style choices, and is used by many different companies. Where not discussed here or in the Composite guide, follow Google's.
 
 # History
 6/21/16:


### PR DESCRIPTION
Style guide links in docs/Contributing.md and style/styleguide.md were broken. (referencing #67)
Very quick fix so didn't feel like the full template was relevant here. 
