### PR TITLE
Fix CI Lint Verification

### DIFF
--- a/ci/helper-functions.sh
+++ b/ci/helper-functions.sh
@@ -100,6 +100,7 @@ check_exit_code() {
 # runs the linter
 run_linter() {
     for fn in $(git diff --name-only upstream/develop...HEAD -- '*.c' '*.cpp' '*.h' | grep -v "cJSON" | grep -v "ndpi"); do
+        file_modification=()
         while read -r diff_line
         do
             if [[ $diff_line == @@* ]]

--- a/ci/helper-functions.sh
+++ b/ci/helper-functions.sh
@@ -100,47 +100,45 @@ check_exit_code() {
 # runs the linter
 run_linter() {
     for fn in $(git diff --name-only upstream/develop...HEAD -- '*.c' '*.cpp' '*.h' | grep -v "cJSON" | grep -v "ndpi"); do
-        file_modification=()
-        while read -r diff_line
-        do
+        git_file_diff=$(git diff -U0 upstream/develop...HEAD -- $fn)
+        file_modifications=()
+        while read -r diff_line; do
             # line number is denoted by @@ -lines_deleted +lines_added @@
-            if [[ $diff_line == @@* ]]
-            then
+            # For example: @@ -1257,3 +1175,3 @@ onvm_nflib_cleanup(struct onvm_nf_context *nf_context) {
+            # We're interested in 1175, 3 as that shows the lines in the final file
+            if [[ $diff_line == @@* ]]; then
                 diff_line=$(cut -d ' ' -f 3 <<< "$diff_line")
                 diff_line=${diff_line:1}
                 line_start=$(cut -d ',' -f 1 <<< "$diff_line")
                 line_end=$(cut -d ',' -f 2 <<< "$diff_line")
-                # parse out the start and end lines
+                # Expand the comment on one line diff vs multiline->therefore addition
                 [[ ! $line_end == $line_start ]] && line_end=$(($line_start + $line_end))
-                file_modification[$line_start]=$line_end
+                file_modifications[$line_start]=$line_end
                 # create mapping of start of chunk -> end line
-            fi  
-        done < <(git diff -U0 upstream/develop...HEAD -- $fn)
-        # loop through the lines changed in the current file
+            fi
+        done <<< "$git_file_diff"
 
+        # loop through the lines changed in the current file
         file_lint=$(python $SCRIPT_LOC/../style/gwclint.py --verbose=4 $fn 2>&1 | grep -v "Done" | grep -v "Total errors found:")
         errors_found=0
         while read -r line; do
             error_line=$(cut -d ':' -f 2 <<< "$line")
             # lint error is denoted by *:line:*
-            for start in "${!file_modification[@]}"
-            do  
+            for start in "${!file_modifications[@]}"; do
                 # loop through the git diff line numbers
-                end=${file_modification[$start]}
-                if [[ $error_line -ge $start && $error_line -le $end ]]
-                then
+                end=${file_modifications[$start]}
+                if [[ $error_line -ge $start && $error_line -le $end ]]; then
                     # git diff and linter output are in range, add to lint file
                     errors_found=$(($errors_found+1))
                     echo "$line" >> $1
                     break
-                fi  
+                fi
             done
         done <<< "$file_lint"
         # loop through the linter output
-        if [[ $errors_found -gt 0 ]]
-        then
+        if [[ $errors_found -gt 0 ]]; then
             # only output to file if we had errors
             echo "Total errors found: $errors_found" >> $1
-        fi  
+        fi
     done
 }


### PR DESCRIPTION
Currently, CI gives the lint errors from the files changed in a pr, but this update only gives lint errors from only lines modified from the pull request, not the entire file. 

## Summary:
This affects the pull request review process with onvm. If all goes well, CI should be able to approve pr changes, even in files where there are usually a lot of linter errors. In many previous PRs, the linter thought that the pr caused issues, where the file just normally has acceptable errors. This would happen even if the modified lines didn't have anything to do with the linter errors. Now this will be fixed. 

**Usage:**
@onvm (the usual)

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  👍
| Bug fixes                |
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [x] PR is ready for review
 - [x] Test merge conflicts in cluster CI


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:
Comment 'onvm'  in different pull requests to see if the linter output works 

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
(optional) << @-mention people who should review these changes >>
Check if we can merge with current ci - @koolzz 

(optional) **Subscribers:** << @-mention people who probably care about these changes >>
