### PR TITLE
[Bug Fix] Update API Call for Speed Tester pcap mode

### DIFF
--- a/examples/speed_tester/speed_tester.c
+++ b/examples/speed_tester/speed_tester.c
@@ -450,7 +450,7 @@ nf_setup(struct onvm_nf_local_ctx *nf_local_ctx) {
                         pkts[i++] = pkt;
                         pkts_generated++;
                 }
-                onvm_nflib_return_pkt_bulk(nf_local_ctx->nf_info, pkts, pkts_generated);
+                onvm_nflib_return_pkt_bulk(nf_local_ctx->nf, pkts, pkts_generated);
         } else {
 #endif
                 /*  use default number of initial packets if -c has not been used */


### PR DESCRIPTION
Updates the return_bult api call for Speed Tester when in pcap mode 

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                |
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [ ] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
(optional) << @-mention people who should review these changes >>

(optional) **Subscribers:** << @-mention people who probably care about these changes >>
