### PR TITLE
[Bug Fix] Add NF Cleanup after Critical Errors

### DIFF
--- a/examples/speed_tester/speed_tester.c
+++ b/examples/speed_tester/speed_tester.c
@@ -450,7 +450,7 @@ nf_setup(struct onvm_nf_local_ctx *nf_local_ctx) {
                         pkts[i++] = pkt;
                         pkts_generated++;
                 }
-                onvm_nflib_return_pkt_bulk(nf_local_ctx->nf_info, pkts, pkts_generated);
+                onvm_nflib_return_pkt_bulk(nf_local_ctx->nf, pkts, pkts_generated);
         } else {
 #endif
                 /*  use default number of initial packets if -c has not been used */

--- a/examples/speed_tester/speed_tester.c
+++ b/examples/speed_tester/speed_tester.c
@@ -328,8 +328,10 @@ run_advanced_rings(struct onvm_nf_local_ctx *nf_local_ctx) {
 
         /* Set core affinity depending on what we got from mgr */
         /* TODO as this is advanced ring mode it should have access to the core info struct */
-        if (onvm_threading_core_affinitize(nf->thread_info.core) < 0)
+        if (onvm_threading_core_affinitize(nf->thread_info.core) < 0){
+                onvm_nflib_stop(nf_local_ctx);
                 rte_exit(EXIT_FAILURE, "Failed to affinitize to core %d\n", nf->thread_info.core);
+        }
 
         printf("Process %d handling packets using advanced rings\n", nf->instance_id);
         start_time = rte_get_tsc_cycles();
@@ -416,6 +418,7 @@ nf_setup(struct onvm_nf_local_ctx *nf_local_ctx) {
                 pcap = pcap_open_offline(pcap_filename, errbuf);
                 if (pcap == NULL) {
                         fprintf(stderr, "Error reading pcap file: %s\n", errbuf);
+                        onvm_nflib_stop(nf_local_ctx);
                         rte_exit(EXIT_FAILURE, "Cannot open pcap file\n");
                 }
 
@@ -505,8 +508,10 @@ nf_setup(struct onvm_nf_local_ctx *nf_local_ctx) {
         }
 #endif
         /* Exit if packets were unexpectedly not created */
-        if (pkts_generated == 0 && packet_number > 0)
+        if (pkts_generated == 0 && packet_number > 0){
+                onvm_nflib_stop(nf_local_ctx);
                 rte_exit(EXIT_FAILURE, "Failed to create packets\n");
+        }
 
         packet_number = pkts_generated;
 }

--- a/examples/speed_tester/speed_tester.c
+++ b/examples/speed_tester/speed_tester.c
@@ -328,7 +328,7 @@ run_advanced_rings(struct onvm_nf_local_ctx *nf_local_ctx) {
 
         /* Set core affinity depending on what we got from mgr */
         /* TODO as this is advanced ring mode it should have access to the core info struct */
-        if (onvm_threading_core_affinitize(nf->thread_info.core) < 0){
+        if (onvm_threading_core_affinitize(nf->thread_info.core) < 0) {
                 onvm_nflib_stop(nf_local_ctx);
                 rte_exit(EXIT_FAILURE, "Failed to affinitize to core %d\n", nf->thread_info.core);
         }
@@ -508,7 +508,7 @@ nf_setup(struct onvm_nf_local_ctx *nf_local_ctx) {
         }
 #endif
         /* Exit if packets were unexpectedly not created */
-        if (pkts_generated == 0 && packet_number > 0){
+        if (pkts_generated == 0 && packet_number > 0) {
                 onvm_nflib_stop(nf_local_ctx);
                 rte_exit(EXIT_FAILURE, "Failed to create packets\n");
         }


### PR DESCRIPTION
Speed test had some outstanding errors where we `rte_exit` without cleaning up context

## Summary:
There were a few places where we would exit because of an error after registering the nf with the manager, but didn't clean up properly. This would cause the manager to think the nf was still running, even when it already exited. 

**Usage:**
Speed test, when pcap was enabled, if you input an invalid pcap file, this would break manager. Also, when not enough packets could be created for speed_tester this happens. These are two odd edge cases that we've caught in the past, but didn't remember to verify after changing how we exit NFs. There might be other places, but these were the only other ones I found, and couldn't find other relevant ones in other NFs. 

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                | 👍
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 

## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [ ] PR is ready for review
 - [ ] Make sure other NFs don't have a similar problem, firewall and scaling, most pertinently 


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:
First test that the functionality works and doesn't break on the test cases. Also, I checked if other NFs had similar problems (rte_exit was called but `onvm_nflib_stop(nf_local_ctx)` was not). I did not see any places in other NFs like this, but I might have missed them. Something to keep in mind. 

## Review: 
@koolzz @dennisafa 

(optional) **Subscribers:** << @-mention people who probably care about these changes >>
