### PR TITLE
[Bug Fix] Prevent Double Shutdown Issues

### DIFF
--- a/onvm/onvm_nflib/onvm_common.h
+++ b/onvm/onvm_nflib/onvm_common.h
@@ -245,6 +245,7 @@ struct onvm_nf_local_ctx {
         struct onvm_nf *nf;
         rte_atomic16_t nf_init_finished;
         rte_atomic16_t keep_running;
+        rte_atomic16_t nf_stopped;
 };
 
 /*

--- a/onvm/onvm_nflib/onvm_nflib.c
+++ b/onvm/onvm_nflib/onvm_nflib.c
@@ -244,6 +244,8 @@ onvm_nflib_init_nf_local_ctx(void) {
         rte_atomic16_set(&nf_local_ctx->keep_running, 1);
         rte_atomic16_init(&nf_local_ctx->nf_init_finished);
         rte_atomic16_set(&nf_local_ctx->nf_init_finished, 0);
+        rte_atomic16_init(&nf_local_ctx->nf_stopped);
+        rte_atomic16_set(&nf_local_ctx->nf_stopped, 0);
 
         return nf_local_ctx;
 }
@@ -665,6 +667,13 @@ onvm_nflib_send_msg_to_nf(uint16_t dest, void *msg_data) {
 
 void
 onvm_nflib_stop(struct onvm_nf_local_ctx *nf_local_ctx) {
+        if (nf_local_ctx == NULL || nf_local_ctx->nf == NULL || rte_atomic16_read(&nf_local_ctx->nf_stopped) != 0) {
+                return;
+        }
+
+        /* Ensure we only call nflib_stop once */
+        rte_atomic16_set(&nf_local_ctx->nf_stopped, 1);
+
         /* Terminate children */
         onvm_nflib_terminate_children(nf_local_ctx->nf);
         /* Stop and free */


### PR DESCRIPTION
Before if `onvm_nflib_stop` would be called 2 times we would see weird behavior, this PR fixes that by adding an atomic flag such that we only execute the shutdown sequence once.

Kudos to @dennisafa for finding this

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                |
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [ ] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
@dennisafa pls