### PR TITLE
[Bug Fix] Return Proper Error Codes for NF Init Failure

### DIFF
--- a/onvm/onvm_nflib/onvm_common.h
+++ b/onvm/onvm_nflib/onvm_common.h
@@ -80,7 +80,7 @@
 #define MANUAL_CORE_ASSIGNMENT_BIT 0
 #define SHARE_CORE_BIT 1
 
-#define ONVM_SIGNAL_TERMINATION -2
+#define ONVM_SIGNAL_TERMINATION -999
 
 /* Maximum length of NF_TAG including the \0 */
 #define TAG_SIZE 15

--- a/onvm/onvm_nflib/onvm_nflib.c
+++ b/onvm/onvm_nflib/onvm_nflib.c
@@ -416,8 +416,8 @@ onvm_nflib_start_nf(struct onvm_nf_local_ctx *nf_local_ctx, struct onvm_nf_init_
                 if (!rte_atomic16_read(&nf_local_ctx->keep_running)) {
                         /* Wait because we sent a message to the onvm_mgr */
                         for (i = 0; i < NF_TERM_INIT_ITER_TIMES && nf_init_cfg->status != NF_STARTING; i++) {
-                                sleep(NF_TERM_WAIT_TIME);
                                 printf("Waiting for onvm_mgr to recieve the message before shutting down\n");
+                                sleep(NF_TERM_WAIT_TIME);
                         }
                         /* Mark init as finished, even though we're exiting onvm_nflib_stop will do proper cleanup */
                         if (nf_init_cfg->status == NF_STARTING) {


### PR DESCRIPTION
Properly return error codes on NF init failure

<!-- Add detailed description and provide running instructions -->
## Summary:
 - First off we have error codes, its a good idea to return those
 - Additionally when onvm_mgr is dead and we start the NF I've cleaned up the shutdown sequence

**Usage:**
Check error codes

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  👍 
| Bug fixes                | 👍 
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [x] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
@dennisafa @kevindweb would appreciate if you tested/reviewed this.
