### PR TITLE
[Bug Fix] Fix Typo in Stats Header

### DIFF
--- a/onvm/onvm_mgr/onvm_stats.h
+++ b/onvm/onvm_mgr/onvm_stats.h
@@ -62,11 +62,11 @@ extern const char *NF_MSG[3];
         "NF TAG         IID / SID / CORE    rx_pps  /  tx_pps        rx_drop  /  tx_drop           out   /    tonf     /   drop\n"\
         "----------------------------------------------------------------------------------------------------------------------\n"
 #define ONVM_STATS_ADV_MSG "\n"\
-        "NF TAG         IID / SID / CORE    rx_pps  /  tx_pps        rx_drop  /  tx_drop           out   /    tonf     /   drop\n"\
+        "NF TAG         IID / SID / CORE    rx_pps  /  tx_pps             rx  /  tx                out   /    tonf     /   drop\n"\
         "               PNT / S|W / CHLD  drop_pps  /  drop_pps      rx_drop  /  tx_drop           next  /    buf      /   ret\n"\
         "----------------------------------------------------------------------------------------------------------------------\n"
 #define ONVM_STATS_SHARED_CORE_MSG "\n"\
-        "NF TAG         IID / SID / CORE    rx_pps  /  tx_pps        rx_drop  /  tx_drop           out   /    tonf     /   drop\n"\
+        "NF TAG         IID / SID / CORE    rx_pps  /  tx_pps             rx  /  tx                out   /    tonf     /   drop\n"\
         "               PNT / S|W / CHLD  drop_pps  /  drop_pps      rx_drop  /  tx_drop           next  /    buf      /   ret\n"\
         "                                  wakeups  /  wakeup_rt\n"\
         "----------------------------------------------------------------------------------------------------------------------\n"


### PR DESCRIPTION
The header says rx_drop and tx_drop but its actually rx and tx stat, this pr fixes that.

<!-- Add detailed description and provide running instructions -->
## Summary:
Yeaaaaa, can't believe I didn't notice this one during release review.
First bug of 19.05, kudos to @Grace-Liu for helping find this one

**Usage:**
Just test the stats output modes.

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                | 👍 
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [x] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:
Can someone look through the args and confirm everything else is in the right spot

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
Pls review