### PR TITLE
Macros for running flow table lookup

### DIFF
--- a/onvm/onvm_mgr/Makefile
+++ b/onvm/onvm_mgr/Makefile
@@ -35,6 +35,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# set this to 1 if onvm is using flow table lookup for incoming packets
+ENABLE_FLOW_LOOKUP=1
+
 ifeq ($(RTE_SDK),)
 $(error "Please define RTE_SDK environment variable")
 endif
@@ -61,6 +64,10 @@ CFLAGS += $(WERROR_FLAGS) -O3 $(USER_FLAGS)
 CFLAGS += -I$(SRCDIR)/../ -I$(SRCDIR)/../onvm_nflib/ -I$(SRCDIR)/../lib/
 LDFLAGS += $(SRCDIR)/../lib/$(RTE_TARGET)/libonvmhelper.a
 LDFLAGS += $(SRCDIR)/../onvm_nflib/$(RTE_TARGET)/libonvm.a
+
+ifeq ($(ENABLE_FLOW_LOOKUP), 1)
+CFLAGS +=-D FLOW_LOOKUP
+endif
 
 # for newer gcc, e.g. 4.4, no-strict-aliasing may not be necessary
 # and so the next line can be removed in those cases.

--- a/onvm/onvm_mgr/Makefile
+++ b/onvm/onvm_mgr/Makefile
@@ -35,7 +35,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# set this to 1 if onvm is using flow table lookup for incoming packets
+# set this to 0 to disable flow table lookup for incoming packets
 ENABLE_FLOW_LOOKUP=1
 
 ifeq ($(RTE_SDK),)


### PR DESCRIPTION
Referencing issue #62 , this pr adds a macro `FLOW_LOOKUP` to `onvm_pkt.c` to enable/disable our flow table lookup. 

## Summary:
Although this is a "good first issue", it's been an issue for a while, and @koolzz  and I found it was very useful for testing the pktgen functionality in CI. Here's what I received with this added functionality. With ` ENABLE_FLOW_LOOKUP=1`, from the max rx was `13331727`, max tx was `14811688`. Disabling the flow table lookup portion of `onvm_pkt_process_rx_batch`, we received max rx of `14783964`, and max tx of `14785566`. Over 1mil pps rx faster by disabling the flow table, which makes sense, but is good that we got it. 

**Usage:**
By default, per @twood02 's request in the original issue, flow lookups happen. But in `/onvm/onvm_mgr/Makefile` setting ` ENABLE_FLOW_LOOKUP=0`, flow lookups will not happen. This is useful if only one port is running pktgen. 

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | #62 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                |
| New functionality        | 👍 
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  
I want to merge this into the upcoming CI pktgen update, to leverage this functionality. We saw a 6mil pps increase by using this on the cluster nodes the other day. (no strict dependencies though)

**TODO before merging :**
 - [ ] PR is ready for review

## Test Plan:
Make sure pktgen still works. 

## Review: 
@koolzz you were there on Saturday talking about this
@dennisafa I know you work a lot with Pktgen, if you could test this