### PR TITLE
Environment Setup Message

### DIFF
--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -61,12 +61,10 @@ if [ -z "$RTE_SDK" ]; then
     exit 1
 fi
 
+# Grab scripts parent directory location
+start_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ >/dev/null 2>&1 && pwd )"
 # Ensure we're working relative to the onvm root directory
-if [ $(basename $(pwd)) == "scripts" ]; then
-    cd ..
-fi
-
-start_dir=$(pwd)
+cd $start_dir
 
 if [ -z "$ONVM_HOME" ]; then
     echo "Please export \$ONVM_HOME and set it to $start_dir"

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -62,12 +62,10 @@ if [ -z "$RTE_SDK" ]; then
 fi
 
 # Grab scripts parent directory location
-start_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ >/dev/null 2>&1 && pwd )"
-# Ensure we're working relative to the onvm root directory
-cd $start_dir
+onvm_home_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ >/dev/null 2>&1 && pwd )"
 
 if [ -z "$ONVM_HOME" ]; then
-    echo "Please export \$ONVM_HOME and set it to $start_dir"
+    echo "Please export \$ONVM_HOME and set it to $onvm_home_dir"
     exit 1
 fi
 


### PR DESCRIPTION
Fixed environment setup message by immediately changing directory to the correct ONVM directory on start. We can run setup from anywhere.

## Summary:
Fixes issue #118. @koolzz I think I can get rid of the `cd $start_dir`, because in the script, we don't actually use any relative paths (we just use exported variables). Changing directory is kind of useless. Also, why do we sleep at line 94 and 104?

**Usage:**

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | #118 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                |
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [ ] PR is ready for review

## Test Plan:

## Review: 
@koolzz please make sure this doesn't break anything.
