### PR TITLE
Manager and Examples check go scripts

### DIFF
--- a/examples/go.sh
+++ b/examples/go.sh
@@ -10,4 +10,13 @@ if [ ! -f ../start_nf.sh ]; then
   exit 1
 fi
 
+SCRIPT=$(readlink -f "$0")
+MANAGER_PATH=$(dirname $(dirname "$SCRIPT"))
+
+if [[ -z $(ps ww -u root | grep "$MANAGER_PATH/onvm/onvm_mgr/$RTE_TARGET/onvm_mgr") ]]
+then
+    echo "NF cannot start without a running manager"
+    exit 1
+fi
+
 ../start_nf.sh $NF_DIR "$@"

--- a/onvm/go.sh
+++ b/onvm/go.sh
@@ -37,7 +37,7 @@ SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
 verbosity=1
 
-if [[ ! -z $(ps ww -u root | grep "$SCRIPTPATH/onvm_mgr/$RTE_TARGET/onvm_mgr") ]]
+if [[ ! -z $(ps ww -u root | grep "$SCRIPTPATH/onvm_mgr/$RTE_TARGET/onvm_mgr" | grep -v "grep") ]]
 then
     echo "Manager cannot be started while another is running"
     exit 1

--- a/onvm/go.sh
+++ b/onvm/go.sh
@@ -37,6 +37,12 @@ SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
 verbosity=1
 
+if [[ ! -z $(ps ww -u root | grep "$SCRIPTPATH/onvm_mgr/$RTE_TARGET/onvm_mgr") ]]
+then
+    echo "Manager cannot be started while another is running"
+    exit 1
+fi
+
 shift 3
 
 if [ -z $nf_cores ]


### PR DESCRIPTION
Our list of enhancements asks for checks to send a message and stop go scripts on certain fatal cases.

<!-- Add detailed description and provide running instructions -->
## Summary:
ONVM go script should print a message and stop running if another manager is already running. Examples go script should print a message and exit if the manager is not running. The second case is not fatal, but the manager wouldn't be able to start up if an NF started before it. We just need to test that the manager can still run in the normal case and that NFs are not negatively affected.

**Usage:**
Run `./go` scripts in `/onvm` and `/examples`

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          |
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                |
| New functionality        | 👍 
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [ ] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:
Test that starting up the manager or NF examples works as intended normally. Test that go script stops running in the previously mentioned cases.

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
@koolzz @dennisafa 
