### PR TITLE
Updated moongen installation memo link, updated pktgen installation m…

### DIFF
--- a/docs/Install.md
+++ b/docs/Install.md
@@ -178,7 +178,7 @@ Configuring environment post reboot
 --
 After a reboot, you can configure your environment again (load kernel modules and bind the NIC) by running the [environment setup script](../scripts/setup_environment.sh).
 
-Also, please double check if the environment variables from [step 3](#3-set-up-environment) are initialized.  If they are not, please go to [step 3](#3-set-up-environment)
+Also, please double check if the environment variables from [step 3](#set-up-environment) are initialized.  If they are not, please go to [step 3](#set-up-environment)
 
 Troubleshooting
 --

--- a/docs/moongen.md
+++ b/docs/moongen.md
@@ -1,7 +1,7 @@
 MoonGen Installation (DPDK-2.0 Version)
 ===================
 
-#### Welcome to installation memo for [MoonGen](http://arxiv.org/ftp/arxiv/papers/1410/1410.3322.pdf), MoonGen is a "Scriptable High-Speed Packet Generator". 
+#### Welcome to installation memo for [MoonGen](http://scholzd.github.io/MoonGen/install.html), MoonGen is a "Scriptable High-Speed Packet Generator". 
 ----------
 
 1. Preparation steps 

--- a/tools/Pktgen/README.md
+++ b/tools/Pktgen/README.md
@@ -4,7 +4,7 @@ Pktgen Installation
 
 
 
-#### Welcome to installation memo for [Pktgen](http://pktgen.readthedocs.org/en/latest/index.html), Pktgen is an app build on [DPDK](http://dpdk.org/),  which is a high performance traffic generator. 
+#### Welcome to installation memo for [Pktgen](https://pktgen-dpdk.readthedocs.io/en/latest/getting_started.html), Pktgen is an app build on [DPDK](http://dpdk.org/),  which is a high performance traffic generator. 
 
 This guide is assuming that you have already got openNetVM installed on your machine, if not, please follow installation guide for openNetVM in file ***INSTALL.md***. 
 


### PR DESCRIPTION
Fixed broken links in documentation files (fixes issue #187)

## Summary:
Fixed MoonGen installation guide ink in `openNetVM/docs/NF_Dev.md`. Fixed Pktgen installation guide link in `openNetVM/tools/Pktgen/README.md`. Fixed "step 3" anchors in `openNetVM/docs/Install.md` so now we can click on the "step 3" link and be redirected to the correct section in the install guide.  

**Usage:**

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | X <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                |
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [X] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:
Previewed documentation files that were altered and tested new links to make sure they were redirecting correctly. 

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 

