### PR TITLE
Update UDP packet information printing

### DIFF
--- a/onvm/onvm_nflib/onvm_pkt_helper.c
+++ b/onvm/onvm_nflib/onvm_pkt_helper.c
@@ -267,10 +267,10 @@ onvm_pkt_print_tcp(struct tcp_hdr* hdr) {
 
 void
 onvm_pkt_print_udp(struct udp_hdr* hdr) {
-        printf("Source Port: %" PRIu16 "\n", hdr->src_port);
-        printf("Destination Port: %" PRIu16 "\n", hdr->dst_port);
-        printf("Length: %" PRIu16 "\n", hdr->dgram_len);
-        printf("Checksum: %" PRIu16 "\n", hdr->dgram_cksum);
+        printf("Source Port: %" PRIu16 "\n", rte_be_to_cpu_16(hdr->src_port));
+        printf("Destination Port: %" PRIu16 "\n", rte_be_to_cpu_16(hdr->dst_port));
+        printf("Length: %" PRIu16 "\n", rte_be_to_cpu_16(hdr->dgram_len));
+        printf("Checksum: %" PRIu16 "\n", rte_be_to_cpu_16(hdr->dgram_cksum));
 }
 
 void


### PR DESCRIPTION
This PR updates the printing of UDP header information. The headers were printed in their big-endian form and are now printed in the CPU order. 

This PR resolves #203 

<!-- Add detailed description and provide running instructions -->
## Summary:

**Usage:**

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          |  👍
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                | 👍
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [x] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
(optional) << @-mention people who should review these changes >>

(optional) **Subscribers:** << @-mention people who probably care about these changes >>
