### PR TITLE
MAC address fix

### DIFF
--- a/examples/load_balancer/load_balancer.c
+++ b/examples/load_balancer/load_balancer.c
@@ -532,7 +532,7 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta,
 
         if (pkt->port == lb->server_port) {
                 if (onvm_get_macaddr(lb->client_port, &ehdr->s_addr) == -1) {
-                        rte_exit(EXIT_FAILURE, "Failed to obtain MAC address\n");
+                        onvm_get_fake_macaddr(&ehdr->s_addr);
                 }
                 for (i = 0; i < ETHER_ADDR_LEN; i++) {
                         ehdr->d_addr.addr_bytes[i] = flow_info->s_addr_bytes[i];
@@ -542,7 +542,7 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta,
                 meta->destination = lb->client_port;
         } else {
                 if (onvm_get_macaddr(lb->server_port, &ehdr->s_addr) == -1) {
-                        rte_exit(EXIT_FAILURE, "Failed to obtain MAC address\n");
+                        onvm_get_fake_macaddr(&ehdr->s_addr);
                 }
                 for (i = 0; i < ETHER_ADDR_LEN; i++) {
                         ehdr->d_addr.addr_bytes[i] = lb->server[flow_info->dest].d_addr_bytes[i];

--- a/examples/load_balancer/load_balancer.c
+++ b/examples/load_balancer/load_balancer.c
@@ -532,7 +532,7 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta,
 
         if (pkt->port == lb->server_port) {
                 if (onvm_get_macaddr(lb->client_port, &ehdr->s_addr) == -1) {
-                        onvm_get_fake_macaddr(&ehdr->s_addr);
+                        rte_exit(EXIT_FAILURE, "Failed to obtain MAC address\n");
                 }
                 for (i = 0; i < ETHER_ADDR_LEN; i++) {
                         ehdr->d_addr.addr_bytes[i] = flow_info->s_addr_bytes[i];
@@ -542,7 +542,7 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta,
                 meta->destination = lb->client_port;
         } else {
                 if (onvm_get_macaddr(lb->server_port, &ehdr->s_addr) == -1) {
-                        onvm_get_fake_macaddr(&ehdr->s_addr);
+                        rte_exit(EXIT_FAILURE, "Failed to obtain MAC address\n");
                 }
                 for (i = 0; i < ETHER_ADDR_LEN; i++) {
                         ehdr->d_addr.addr_bytes[i] = lb->server[flow_info->dest].d_addr_bytes[i];

--- a/examples/load_generator/load_generator.c
+++ b/examples/load_generator/load_generator.c
@@ -328,7 +328,7 @@ nf_setup(struct onvm_nf_local_ctx *nf_local_ctx) {
         }
 
         if (onvm_get_macaddr(0, &ehdr->s_addr) == -1) {
-                rte_exit(EXIT_FAILURE, "Failed to obtain MAC address\n");
+                onvm_get_fake_macaddr(&ehdr->s_addr);
         }
         for (j = 0; j < ETHER_ADDR_LEN; ++j) {
                 ehdr->d_addr.addr_bytes[j] = d_addr_bytes[j];

--- a/examples/load_generator/load_generator.c
+++ b/examples/load_generator/load_generator.c
@@ -326,7 +326,7 @@ nf_setup(struct onvm_nf_local_ctx *nf_local_ctx) {
         if (ehdr == NULL) {
                 rte_exit(EXIT_FAILURE, "Failed to allocate common ehdr\n");
         }
-        
+
         if (onvm_get_macaddr(0, &ehdr->s_addr) == -1) {
                 RTE_LOG(INFO, APP, "Using fake MAC address\n");
                 onvm_get_fake_macaddr(&ehdr->s_addr);
@@ -343,7 +343,7 @@ main(int argc, char *argv[]) {
         struct onvm_nf_local_ctx *nf_local_ctx;
         struct onvm_nf_function_table *nf_function_table;
         const char *progname = argv[0];
-        
+
         nf_local_ctx = onvm_nflib_init_nf_local_ctx();
         onvm_nflib_start_signal_handler(nf_local_ctx, NULL);
 

--- a/examples/load_generator/load_generator.c
+++ b/examples/load_generator/load_generator.c
@@ -326,8 +326,9 @@ nf_setup(struct onvm_nf_local_ctx *nf_local_ctx) {
         if (ehdr == NULL) {
                 rte_exit(EXIT_FAILURE, "Failed to allocate common ehdr\n");
         }
-
+        
         if (onvm_get_macaddr(0, &ehdr->s_addr) == -1) {
+                RTE_LOG(INFO, APP, "Using fake MAC address\n");
                 onvm_get_fake_macaddr(&ehdr->s_addr);
         }
         for (j = 0; j < ETHER_ADDR_LEN; ++j) {
@@ -342,7 +343,7 @@ main(int argc, char *argv[]) {
         struct onvm_nf_local_ctx *nf_local_ctx;
         struct onvm_nf_function_table *nf_function_table;
         const char *progname = argv[0];
-
+        
         nf_local_ctx = onvm_nflib_init_nf_local_ctx();
         onvm_nflib_start_signal_handler(nf_local_ctx, NULL);
 

--- a/examples/speed_tester/speed_tester.c
+++ b/examples/speed_tester/speed_tester.c
@@ -379,6 +379,7 @@ nf_setup(struct onvm_nf_local_ctx *nf_local_ctx) {
                         *using input string for dest addr
                         */
                         if (onvm_get_macaddr(0, &ehdr->s_addr) == -1) {
+                                RTE_LOG(INFO, APP, "Using fake MAC address\n");
                                 onvm_get_fake_macaddr(&ehdr->s_addr);
                         }
                         for (j = 0; j < ETHER_ADDR_LEN; ++j) {


### PR DESCRIPTION
Fixes the load_generator bug mentioned in #222 

## Summary:
In order to resolve the issue where the "Failed to obtain MAC address" error is raised in the load_generator NF, the function onvm_get_fake_macaddr() is used to obtain a fake MAC address for testing or in the case that the provided MAC address of the port is not bound to DPDK. 

**Usage:**
 
<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                | 👍 
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [X] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:

Ran the load_generator NF with the MAC address of the node I am testing with. I had @sreya519 run this fix for the load_generator as well since she experienced this error. 

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
@sreya519 --> tested the load_generator fixes already
