### PR TITLE
Use NF data instead of global variables.

### DIFF
--- a/examples/simple_fwd_tb/forward_tb.c
+++ b/examples/simple_fwd_tb/forward_tb.c
@@ -53,6 +53,7 @@
 #include <rte_cycles.h>
 #include <rte_ip.h>
 #include <rte_mbuf.h>
+#include <rte_malloc.h>
 
 #include "onvm_nflib.h"
 #include "onvm_pkt_helper.h"
@@ -106,7 +107,7 @@ parse_app_args(int argc, char *argv[], const char *progname, struct onvm_nf *nf)
         int c, dst_flag = 0;
         struct tb_config *tb_params;
 
-        tb_params = (struct tb_config *)malloc(sizeof(struct tb_config));
+        tb_params = (struct tb_config *)rte_malloc(NULL, sizeof(struct tb_config), 0);
         /* Assigning default values */
         tb_params->tb_rate = 1000;
         tb_params->tb_depth = 10000;
@@ -247,8 +248,6 @@ packet_handler_tb(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta,
                 counter = 0;
         }
 
-        tb_params->tb_rate = tb_rate;
-        tb_params->tb_depth = tb_depth;
         tb_params->tb_tokens = tb_tokens;
         tb_params->last_cycle = last_cycle;
         tb_params->cur_cycles = cur_cycles;

--- a/examples/simple_fwd_tb/forward_tb.c
+++ b/examples/simple_fwd_tb/forward_tb.c
@@ -68,7 +68,7 @@ static uint32_t destination;
 
 /* Token Bucket */
 struct tb_config {
-        uint64_t tb_rate;    // rate at which tokens are generated (in Mbps)
+        uint64_t tb_rate;    // rate at which tokens are generated (in MBps)
         uint64_t tb_depth;   // depth of the token bucket (in bytes)
         uint64_t tb_tokens;  // number of the tokens in the bucket at any given time (in bytes)
 


### PR DESCRIPTION
Use NF data instead of global variables.

Before realizing that the compiler optimizes pointer references, I used local variables in the packet_handler. But then it just seemed neater and easier to read that way. Let me know if I should remove the local variables used there.

## Summary:

| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                |
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 

## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [x] PR is ready for review


## Test Plan:

Tested with new changes, the program works as before.

## Review:

@twood02 