### PR TITLE
Update stats for outgoing packets

### DIFF
--- a/onvm/onvm_nflib/onvm_pkt_common.c
+++ b/onvm/onvm_nflib/onvm_pkt_common.c
@@ -111,10 +111,10 @@ onvm_pkt_process_tx_batch(struct queue_mgr *tx_mgr, struct rte_mbuf *pkts[], uin
                         nf->stats.act_tonf++;
                         onvm_pkt_enqueue_nf(tx_mgr, meta->destination, pkts[i], nf);
                 } else if (meta->action == ONVM_NF_ACTION_OUT) {
-                        nf->stats.act_out++;
                         if (tx_mgr->mgr_type_t == MGR) {
                                 onvm_pkt_enqueue_port(tx_mgr, meta->destination, pkts[i]);
                         } else {
+                                nf->stats.act_out++;
                                 out_buf = tx_mgr->to_tx_buf;
                                 out_buf->buffer[out_buf->count++] = pkts[i];
                                 if (out_buf->count == PACKET_READ_SIZE) {

--- a/onvm/onvm_nflib/onvm_pkt_common.c
+++ b/onvm/onvm_nflib/onvm_pkt_common.c
@@ -111,15 +111,15 @@ onvm_pkt_process_tx_batch(struct queue_mgr *tx_mgr, struct rte_mbuf *pkts[], uin
                         nf->stats.act_tonf++;
                         onvm_pkt_enqueue_nf(tx_mgr, meta->destination, pkts[i], nf);
                 } else if (meta->action == ONVM_NF_ACTION_OUT) {
-                        if (tx_mgr->mgr_type_t == MGR) {
-                                onvm_pkt_enqueue_port(tx_mgr, meta->destination, pkts[i]);
-                        } else {
+                        if (tx_mgr->mgr_type_t != MGR) {
                                 nf->stats.act_out++;
                                 out_buf = tx_mgr->to_tx_buf;
                                 out_buf->buffer[out_buf->count++] = pkts[i];
                                 if (out_buf->count == PACKET_READ_SIZE) {
                                         onvm_pkt_enqueue_tx_thread(out_buf, nf);
                                 }
+                        } else {
+                                onvm_pkt_enqueue_port(tx_mgr, meta->destination, pkts[i]);
                         }
                 } else {
                         printf("ERROR invalid action : this shouldn't happen.\n");


### PR DESCRIPTION
Update stats updating during ONVM_NF_ACTION_OUT action.

<!-- Add detailed description and provide running instructions -->
## Summary:

ONVM stats was updating stats.act_out twice. 

This will occur when sending out packets out a port. 
To replicate this run bridge ./go.sh 2 and send packets with speed tester to the bridge nf ./go.sh 1 -d 2
Before:
![image](https://user-images.githubusercontent.com/54540257/84348929-cb4ffa00-abe8-11ea-9ea4-fa603b87f2a2.png)
After:
![image](https://user-images.githubusercontent.com/54540257/84348946-d440cb80-abe8-11ea-9fb0-3285f43857fb.png)


**Usage:**

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                | 👍 
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [👍 ] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:
Check  output of ONVM stats for correct values. 

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 

@sreya519 