### PR TITLE
Fix for Manager go.sh Incorrectly Comparing Ports Available

### DIFF
--- a/onvm/go.sh
+++ b/onvm/go.sh
@@ -63,15 +63,9 @@ then
 fi
 
 ports_bin=$(echo "obase=2; ibase=16; $ports" | bc)
-count_ports=0
-while [[ $ports_bin -ne 0 ]]
-do
-    if [[ $((ports_bin % 10)) -eq 1 ]]
-    then
-        count_ports=$((count_ports+1))
-    fi
-    ports_bin=$ports_bin/10
-done
+ports_bin="${ports_bin//0/}"
+count_ports="${#ports_bin}"
+
 ports_detected=$("$RTE_SDK"/usertools/dpdk-devbind.py --status-dev net | sed '/Network devices using kernel driver/q' | grep -c "drv")
 if [[ $ports_detected -lt $count_ports ]]
 then

--- a/onvm/go.sh
+++ b/onvm/go.sh
@@ -48,7 +48,7 @@ fi
 
 shift 3
 
-# Verify that bc is installed
+# Verify that bc is installed 
 if [[ $(command -v bc | grep -c "/usr/bin/bc") == 0 ]]
 then
     echo "Error: bc is not installed. Install using:"

--- a/onvm/go.sh
+++ b/onvm/go.sh
@@ -49,7 +49,7 @@ fi
 shift 3
 
 # Verify that bc is installed
-if [[ $(command -v bc | grep -c "/usr/bin/bc") == 0 ]]
+if [[ -z $(command -v bc) ]]
 then
     echo "Error: bc is not installed. Install using:"
     echo "  sudo apt-get install bc"

--- a/onvm/go.sh
+++ b/onvm/go.sh
@@ -62,8 +62,12 @@ then
     usage
 fi
 
+# Convert the port mask to binary
+# Using bc where obase=2 indicates the output is base 2 and ibase=16 indicates the output is base 16
 ports_bin=$(echo "obase=2; ibase=16; $ports" | bc)
+# Splice out the 0's from the binary numbers. The result is only 1's. Example: 1011001 -> 1111
 ports_bin="${ports_bin//0/}"
+# The number of ports is the length of the string of 1's. Using above example: 1111 -> 4
 count_ports="${#ports_bin}"
 
 ports_detected=$("$RTE_SDK"/usertools/dpdk-devbind.py --status-dev net | sed '/Network devices using kernel driver/q' | grep -c "drv")

--- a/onvm/go.sh
+++ b/onvm/go.sh
@@ -62,21 +62,6 @@ then
     usage
 fi
 
-# Convert the port mask to binary
-# Using bc where obase=2 indicates the output is base 2 and ibase=16 indicates the output is base 16
-ports_bin=$(echo "obase=2; ibase=16; $ports" | bc)
-# Splice out the 0's from the binary numbers. The result is only 1's. Example: 1011001 -> 1111
-ports_bin="${ports_bin//0/}"
-# The number of ports is the length of the string of 1's. Using above example: 1111 -> 4
-count_ports="${#ports_bin}"
-
-ports_detected=$("$RTE_SDK"/usertools/dpdk-devbind.py --status-dev net | sed '/Network devices using kernel driver/q' | grep -c "drv")
-if [[ $ports_detected -lt $count_ports ]]
-then
-    echo "Error: Invalid port mask. Insufficient NICs bound."
-    exit 1
-fi
-
 while getopts "a:r:d:s:t:l:p:z:cv" opt; do
     case $opt in
         a) virt_addr="--base-virtaddr=$OPTARG";;
@@ -93,6 +78,21 @@ while getopts "a:r:d:s:t:l:p:z:cv" opt; do
             ;;
     esac
 done
+
+# Convert the port mask to binary
+# Using bc where obase=2 indicates the output is base 2 and ibase=16 indicates the output is base 16
+ports_bin=$(echo "obase=2; ibase=16; $ports" | bc)
+# Splice out the 0's from the binary numbers. The result is only 1's. Example: 1011001 -> 1111
+ports_bin="${ports_bin//0/}"
+# The number of ports is the length of the string of 1's. Using above example: 1111 -> 4
+count_ports="${#ports_bin}"
+
+ports_detected=$("$RTE_SDK"/usertools/dpdk-devbind.py --status-dev net | sed '/Network devices using kernel driver/q' | grep -c "drv")
+if [[ $ports_detected -lt $count_ports ]]
+then
+    echo "Error: Invalid port mask. Insufficient NICs bound."
+    exit 1
+fi
 
 verbosity_level="-v $verbosity"
 

--- a/onvm/go.sh
+++ b/onvm/go.sh
@@ -48,7 +48,7 @@ fi
 
 shift 3
 
-# Verify that bc is installed 
+# Verify that bc is installed
 if [[ $(command -v bc | grep -c "/usr/bin/bc") == 0 ]]
 then
     echo "Error: bc is not installed. Install using:"

--- a/onvm/go.sh
+++ b/onvm/go.sh
@@ -49,7 +49,7 @@ fi
 shift 3
 
 # Verify that bc is installed
-if [[ $(dpkg-query -W -f='${Status}' bc 2>/dev/null | grep -c "ok installed") == 0 ]]
+if [[ $(command -v bc | grep -c "/usr/bin/bc") == 0 ]]
 then
     echo "Error: bc is not installed. Install using:"
     echo "  sudo apt-get install bc"


### PR DESCRIPTION
Fixed bug in #228 

<!-- Add detailed description and provide running instructions -->
## Summary:

Updated the manager go.sh script to properly count the number of ports referenced in the port mask argument and compares it to the number of ports available for the manager to run on. If the number of ports specified in the hexadecimal port mask is more than the number available, the manager will not start. This is the anticipated behavior.

The bug was the script not converting the hexadecimal mask to binary and counting the digits, but instead taking the hexadecimal port mask and assuming it was the number of ports the manager should attempt to bind to. This has been fixed, since I have converted the hexadecimal port mask to binary and performed modulo operations to determine the number of digits that are "1", which signifies a port in use. This still allows the check to work, by alerting the user when the number of ports they specify in the port mask is higher than the number of ports available to DPDK.

**Usage:**

Run the manager the same as before:
```sh
./go.sh 0,1,2 <port mask> 0xF8 -s stdout
```
where `<port mask>` is the hexadecimal port mask for the ports you want the manager to run on.

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                | 👍 |
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: bc

Similar to PR #219, bc is a new dependency for openNetVM. It can be installed with

sudo apt-get install bc

**TODO before merging :**
 - [x] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:

Tested running the manager on CloudLab, with 2 NICs bound and default arguments, but varied numbers for the hexadecimal port mask. Tried 0, 1, 2, 3, 4, and 7. This ensured that the port number comparison worked. I used 7 because it would have 3 "1's" in the binary number 111, which would equate to ports 0, 1 and 2. This, as it should, caused an error. With 4, though, we notice something interesting. Since 4 is technically 100, there is only one port that would be bound to. The port mask check does not catch this, but the manager does. The manager gives a warning that since port 2 is not configured, the manager will skip attempting to bind to it. 

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
@sreya519 - you initially brought this up as a bug
@kevindweb - you worked with the go.sh scripts frequently