### PR TITLE
Changing PR Template to have a reminder to merge to develop

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- Hey, thanks for contributing to openNetVM! When submitting your Pull Request, please make sure you're submitting to the sdnfv:develop branch; once we have a good set of merged PR's on develop, we'll merge everything to sdnfv:master for a release. -->
+
 <<Replace this line with a short description of the changes>>
 
 <!-- Add detailed description and provide running instructions -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Hey, thanks for contributing to openNetVM! When submitting your Pull Request, please make sure you're submitting to the sdnfv:develop branch; once we have a good set of merged PR's on develop, we'll merge everything to sdnfv:master for a release. -->
+<!-- Hey, thanks for contributing to openNetVM! When submitting your Pull Request, please make sure you're submitting to the sdnfv:develop branch. Once we have a good set of merged PR's on develop, we'll merge everything to sdnfv:master for a release. -->
 
 <<Replace this line with a short description of the changes>>
 


### PR DESCRIPTION
Added reminder for users to submit PR's to develop instead of master

<!-- Add detailed description and provide running instructions -->
## Summary:

Super minor change, but edited the PR template so users are reminded to request their changes be merged onto the develop branch instead of the master branch. This was discussed with @kevindweb and the other undergraduates earlier tonight. 

**Usage:**

Create a new Pull Request (after this is merged) and notice the updated template.

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                |
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [x] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:

Not really a way to test this. Should work 100%, I kept the comment syntax that was used in the template already.