### PR TITLE
Bug fix: Not setting action after adding to table.

### DIFF
--- a/examples/test_flow_dir/test_flow_dir.c
+++ b/examples/test_flow_dir/test_flow_dir.c
@@ -176,7 +176,8 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta,
                 memset(flow_entry, 0, sizeof(struct onvm_flow_entry));
                 flow_entry->sc = onvm_sc_create();
                 onvm_sc_append_entry(flow_entry->sc, ONVM_NF_ACTION_TONF, destination);
-                // onvm_sc_print(flow_entry->sc);
+                meta->destination = destination;
+                meta->action = ONVM_NF_ACTION_TONF;
         }
         return 0;
 }


### PR DESCRIPTION
Test flow directory NF bug fix.

<!-- Add detailed description and provide running instructions -->
## Summary:

The NF was not setting the meta action after adding a new flow to the table.

**Usage:** 
As described in readme.

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                |
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [ ] PR is ready for review

I hope to be making changes to this in the coming few days to add an example for service chaining. As of now this resolves issue #247 

<!-- What you did to test the PR, what needs to be done -->
## Test Plan:

Run NF with Pktgen. Test that NF does not crash as before. 

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
Anyone.
