### PR TITLE
Improve usability of cloudlab profiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,14 @@ ifeq ($(ONVM_HOME),)
 $(error "Please define ONVM_HOME environment variable")
 endif
 
-include $(ONVM_HOME)/onvm/Makefiles
-include $(ONVM_HOME)/examples/Makefiles
-include $(ONVM_HOME)/dpdk/Makefiles
+ifeq ($(RTE_SDK),)
+$(error "Please define RTE_SDK environment variable")
+endif
+
+all:
+	cd $(ONVM_HOME)/dpdk && make
+	cd $(ONVM_HOME)/onvm && make
+	cd $(ONVM_HOME)/examples && make
 
 .PHONY: tags
 

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,14 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+ifeq ($(ONVM_HOME),)
+$(error "Please define ONVM_HOME environment variable")
+endif
+
+include $(ONVM_HOME)/onvm/Makefiles
+include $(ONVM_HOME)/examples/Makefiles
+include $(ONVM_HOME)/dpdk/Makefiles
+
 .PHONY: tags
 
 tags:

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ $(error "Please define RTE_SDK environment variable")
 endif
 
 all:
-	cd $(ONVM_HOME)/dpdk && make
+	# cd $(ONVM_HOME)/dpdk && make
 	cd $(ONVM_HOME)/onvm && make
 	cd $(ONVM_HOME)/examples && make
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _Want to get started quickly?_ Try using our NSF CloudLab profile: https://www.c
 Notes
 --
 
-We have updated our DPDK submodule to point to a new version, v18.11.  If you have already cloned this repository, please update your DPDK submodule by running:
+We have updated our DPDK submodule to point to a new version, v20.05.  If you have already cloned this repository, please update your DPDK submodule by running:
 
 ```
 git submodule sync
@@ -25,7 +25,7 @@ make T=$RTE_TARGET -j 8
 make install T=$RTE_TARGET -j 8
 ```
 
-See our [release](docs/Releases.md) document for more information.
+The current OpenNetVM version is 20.10. Please see our [release](docs/Releases.md) document for more information.
 
 About
 --
@@ -35,7 +35,7 @@ openNetVM is an open source version of the NetVM platform described in our [NSDI
 
 The [develop][dev] branch tracks experimental builds (active development) whereas the [master][mast] branch tracks verified stable releases.  Please read our [releases][rels] document for more information about our releases and release cycle.
 
-You can find information about research projects building on [OpenNetVM][onvm] at the [UCR/GW SDNFV project site][sdnfv]. OpenNetVM is supported in part by NSF grants CNS-1422362 and CNS-1522546. 
+You can find information about research projects building on [OpenNetVM][onvm] at the [UCR/GW SDNFV project site][sdnfv]. OpenNetVM is supported in part by NSF grants CNS-1422362 and CNS-1522546.
 
 Installing
 --

--- a/scripts/setup_cloudlab.sh
+++ b/scripts/setup_cloudlab.sh
@@ -52,3 +52,5 @@ fi
 if [ -z "$ONVM_HOME" ]; then
     export ONVM_HOME=$ONVM_PATH
 fi
+
+bash "$ONVM_HOME"/scripts/setup_environment.sh


### PR DESCRIPTION
<!-- Hey, thanks for contributing to openNetVM! When submitting your Pull Request, please make sure you're submitting to the sdnfv:develop branch. Once we have a good set of merged PR's on develop, we'll merge everything to sdnfv:master for a release. -->

This PR relates to issue #262. I fixed some documentation issues, and improved general usability of onvm.

<!-- Add detailed description and provide running instructions -->
## Summary:
1. Now you can compile everything in the root directory instead of compiling dpdk, manager and examples separately.
2. For cloudlab profiles, you only need to run setup_cloudlab.sh to setup all the environmental variables and do the environment setup.
**Usage:**

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | #262 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   | X
| Bug fixes                |
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [X] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:
Try doing a make in a Ubuntu 20 environment under the root directory, see if it can correctly make everything.
On cloudlab profiles, run setup_cloudlab.sh see if it correctly does the setup.

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
(optional) << @-mention people who should review these changes >>

(optional) **Subscribers:** << @-mention people who probably care about these changes >>
