### PR TITLE
Dockerize 20.10

### DIFF
--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -34,7 +34,7 @@ sudo ./docker.sh -h HUGEPAGES -o ONVM -n NAME [-D DEVICES] [-d DIRECTORY] [-c CO
   - This will start a container with two NIC devices mapped in, /dev/uio0 and /dev/uio1, the hugepage directory at `/mnt/huge` mapped in, and the openNetVM source directory at `/root/openNetVM` mapped into the container with the name of Basic_Monitor_NF.
 
     ```bash
-    sudo ./docker.sh -h /mnt/huge -o /root/openNetVM -n Speed_Tester_NF -D /dev/uio0 -c "./examples/speed_tester/go.sh 1 -d 1"
+    sudo ./docker.sh -h /mnt/huge -o /root/openNetVM -n Speed_Tester_NF -D /dev/uio0 -c "./examples/start_nf.sh speed_tester 1 -d 1"
     ```
 
   - This will start a container with one NIC device mapped in, /dev/uio0 , the hugepage directory at `/mnt/huge` mapped in, and the openNetVM source directory at `/root/openNetVM` mapped into the container with the name of Speed_Tester_NF. Also, the container will be started in detached mode (no connection to it) and it will run the go script of the simple forward NF.
@@ -162,7 +162,7 @@ Older Dockerfiles
 
 If you want to use an older ONVM version on Ubuntu 14, take a look at the [Available Tags][onvm-docker-tags].
 The 18.03 tag runs ONVM when it had been set up for an older version of Ubuntu.
-The `latest` dockerfile runs on Ubuntu 18.04 and is called `latest`.
+The `latest` dockerfile runs on Ubuntu 20.04 and is called `latest`.
 
 [docker]: ../scripts/docker.sh
 [onvm-docker]: https://hub.docker.com/r/sdnfv/opennetvm/

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -34,9 +34,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-FROM ubuntu:18.04
-MAINTAINER "Kevin Deems" <kevin8deems@gmail.com>
-LABEL version="OpenNetVM v19.07"
+FROM ubuntu:20.04
+LABEL maintainer="Kevin Deems kevin8deems@gmail.com"
+LABEL version="OpenNetVM v20.10"
 LABEL vendor="SDNFV @ UCR and GW"
 LABEL github="github.com/sdnfv/openNetVM"
 
@@ -47,13 +47,19 @@ ENV ONVM_NUM_HUGEPAGES=1024
 
 WORKDIR $ONVM_HOME
 
+# Ubuntu 20.04 image hangs unless timezone is set
+RUN DEBIAN_FRONTEND=noninteractive \
+    ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
+
 RUN apt-get update -y && apt-get upgrade -y && \
-    apt-get install -y build-essential \
-                       sudo \
-                       gdb \
-                       python \
-                       libnuma-dev \
-                       vim \
-                       less \
-                       git \
-                       net-tools \
+    apt-get install -y \
+    build-essential \
+    sudo \
+    gdb \
+    python \
+    libnuma-dev \
+    vim \
+    less \
+    git \
+    net-tools \
+    bc

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -84,7 +84,7 @@ if [[ "${CMD}" == "" ]] ; then
         --volume="${ONVM}":/openNetVM \
         ${DIR} \
         "${DEVICES[@]}" \
-        sdnfv/opennetvm \
+        sdnfv/opennetvm:20.10 \
         /bin/bash
 else
     sudo docker run \
@@ -98,7 +98,7 @@ else
         --volume="${ONVM}":/openNetVM \
         ${DIR} \
         "${DEVICES[@]}" \
-        sdnfv/opennetvm \
+        sdnfv/opennetvm.20.10 \
         /bin/bash -c "${CMD}"
 fi
 

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -84,7 +84,7 @@ if [[ "${CMD}" == "" ]] ; then
         --volume="${ONVM}":/openNetVM \
         ${DIR} \
         "${DEVICES[@]}" \
-        sdnfv/opennetvm:20.10 \
+        sdnfv/opennetvm \
         /bin/bash
 else
     sudo docker run \
@@ -98,7 +98,7 @@ else
         --volume="${ONVM}":/openNetVM \
         ${DIR} \
         "${DEVICES[@]}" \
-        sdnfv/opennetvm.20.10 \
+        sdnfv/opennetvm \
         /bin/bash -c "${CMD}"
 fi
 


### PR DESCRIPTION
<!-- Hey, thanks for contributing to openNetVM! When submitting your Pull Request, please make sure you're submitting to the sdnfv:develop branch. Once we have a good set of merged PR's on develop, we'll merge everything to sdnfv:master for a release. -->

Our [Docker Hub Repo](https://hub.docker.com/r/sdnfv/opennetvm/tags) needed to be updated to the latest version of onvm (20.10). 

## Summary:
These updates add a new tag for docker. The `latest` docker image will now pull the ubuntu 20.02 image. 

**Usage:**
The `Docker.md` file explains how to run the manager and NF in containers for testing.

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |  
| Bug fixes                |
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 👍 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [X] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:
Test that the `./docker.sh` command works on ubuntu 20, and ensure that a normal onvm NF w/ manager can run. 

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
@WilliamMaa 