### PR TITLE
Fix json configuration and duplicate instance id bugs

### DIFF
--- a/examples/example_config.json
+++ b/examples/example_config.json
@@ -4,10 +4,9 @@
                 "memory_channels": 3,
                 "portmask": 2
         },
-
         "onvm": {
                 "output": "stdout",
-                "serviceid": 1,
-                "instanceid": 3
+                "serviceid": 5,
+                "instanceid": 7
         }
 }

--- a/examples/example_config.json
+++ b/examples/example_config.json
@@ -6,7 +6,7 @@
         },
         "onvm": {
                 "output": "stdout",
-                "serviceid": 5,
-                "instanceid": 7
+                "serviceid": 1,
+                "instanceid": 3
         }
 }

--- a/examples/start_nf.sh
+++ b/examples/start_nf.sh
@@ -45,6 +45,7 @@ then
   config=$2
   shift 2
   exec sudo "$BINARY" -F "$config" "$@"
+  exit 0
 fi
 
 # Check if -- is present, if so parse dpdk/onvm specific args

--- a/onvm/onvm_mgr/onvm_nf.c
+++ b/onvm/onvm_mgr/onvm_nf.c
@@ -47,9 +47,9 @@
 ******************************************************************************/
 
 #include "onvm_nf.h"
+#include <rte_lpm.h>
 #include "onvm_mgr.h"
 #include "onvm_stats.h"
-#include <rte_lpm.h>
 
 /* ID 0 is reserved */
 uint16_t next_instance_id = 1;
@@ -116,6 +116,16 @@ onvm_nf_init_lpm_region(struct lpm_request *req_lpm);
  */
 static void
 onvm_nf_init_ft(struct ft_request *ft);
+
+/*
+ * Function that clears the tx, rx, & msg_q rings
+ * in case an NF uses this iid in the future
+ *
+ * Input  : An nf struct
+ * Output : none
+ */
+static void
+onvm_nf_clear_rings(struct onvm_nf *nf);
 
 /*
  *  Set up the DPDK rings which will be used to pass packets, via
@@ -192,7 +202,7 @@ onvm_nf_check_status(void) {
                                 onvm_nf_init_lpm_region(req_lpm);
                                 break;
                         case MSG_REQUEST_FT:
-                                ft = (struct ft_request *) msg->msg_data;
+                                ft = (struct ft_request *)msg->msg_data;
                                 onvm_nf_init_ft(ft);
                                 break;
                         case MSG_NF_STARTING:
@@ -370,8 +380,8 @@ onvm_nf_stop(struct onvm_nf *nf) {
                         rte_pktmbuf_free(pkts[i]);
         }
         nf_msg_pool = rte_mempool_lookup(_NF_MSG_POOL_NAME);
-        while (rte_ring_dequeue(nfs[nf_id].msg_q, (void**)(&msg)) == 0) {
-                rte_mempool_put(nf_msg_pool, (void*)msg);
+        while (rte_ring_dequeue(nfs[nf_id].msg_q, (void **)(&msg)) == 0) {
+                rte_mempool_put(nf_msg_pool, (void *)msg);
         }
 
         /* Free info struct */
@@ -380,7 +390,7 @@ onvm_nf_stop(struct onvm_nf *nf) {
         if (nf_info_mp == NULL)
                 return 1;
 
-        rte_mempool_put(nf_info_mp, (void*)nf);
+        rte_mempool_put(nf_info_mp, (void *)nf);
 
         /* Further cleanup is only required if NF was succesfully started */
         if (nf_status != NF_RUNNING && nf_status != NF_PAUSED)
@@ -391,6 +401,9 @@ onvm_nf_stop(struct onvm_nf *nf) {
 
         /* Reset stats */
         onvm_stats_clear_nf(nf_id);
+
+        /* Free rings if another NF uses this instance id */
+        onvm_nf_clear_rings(&nfs[nf_id]);
 
         /* Remove this NF from the service map.
          * Need to shift all elements past it in the array left to avoid gaps */
@@ -429,7 +442,7 @@ onvm_nf_stop(struct onvm_nf *nf) {
 static void
 onvm_nf_init_lpm_region(struct lpm_request *req_lpm) {
         struct rte_lpm_config conf;
-        struct rte_lpm* lpm_region;
+        struct rte_lpm *lpm_region;
 
         conf.max_rules = req_lpm->max_num_rules;
         conf.number_tbl8s = req_lpm->num_tbl8s;
@@ -475,6 +488,13 @@ onvm_nf_relocate_nf(uint16_t dest, uint16_t new_core) {
 }
 
 static void
+onvm_nf_clear_rings(struct onvm_nf *nf) {
+        rte_ring_free(nf->rx_q);
+        rte_ring_free(nf->tx_q);
+        rte_ring_free(nf->msg_q);
+}
+
+static void
 onvm_nf_init_rings(struct onvm_nf *nf) {
         unsigned instance_id;
         unsigned socket_id;
@@ -489,20 +509,16 @@ onvm_nf_init_rings(struct onvm_nf *nf) {
         rq_name = get_rx_queue_name(instance_id);
         tq_name = get_tx_queue_name(instance_id);
         msg_q_name = get_msg_queue_name(instance_id);
-        nf->rx_q =
-                rte_ring_create(rq_name, ringsize, socket_id, RING_F_SC_DEQ); /* multi prod, single cons */
-        nf->tx_q =
-                rte_ring_create(tq_name, ringsize, socket_id, RING_F_SC_DEQ); /* multi prod, single cons */
-        nf->msg_q =
-                rte_ring_create(msg_q_name, msgringsize, socket_id,
-                                RING_F_SC_DEQ); /* multi prod, single cons */
 
+        nf->rx_q = rte_ring_create(rq_name, ringsize, socket_id, RING_F_SC_DEQ); /* multi prod, single cons */
         if (nf->rx_q == NULL)
                 rte_exit(EXIT_FAILURE, "Cannot create rx ring queue for NF %u\n", instance_id);
 
+        nf->tx_q = rte_ring_create(tq_name, ringsize, socket_id, RING_F_SC_DEQ); /* multi prod, single cons */
         if (nf->tx_q == NULL)
                 rte_exit(EXIT_FAILURE, "Cannot create tx ring queue for NF %u\n", instance_id);
 
+        nf->msg_q = rte_ring_create(msg_q_name, msgringsize, socket_id, RING_F_SC_DEQ); /* multi prod, single cons */
         if (nf->msg_q == NULL)
                 rte_exit(EXIT_FAILURE, "Cannot create msg queue for NF %u\n", instance_id);
 }

--- a/onvm/onvm_mgr/onvm_nf.c
+++ b/onvm/onvm_mgr/onvm_nf.c
@@ -47,9 +47,9 @@
 ******************************************************************************/
 
 #include "onvm_nf.h"
-#include <rte_lpm.h>
 #include "onvm_mgr.h"
 #include "onvm_stats.h"
+#include <rte_lpm.h>
 
 /* ID 0 is reserved */
 uint16_t next_instance_id = 1;

--- a/onvm/onvm_mgr/onvm_stats.c
+++ b/onvm/onvm_mgr/onvm_stats.c
@@ -455,10 +455,21 @@ onvm_stats_display_nfs(unsigned difftime, uint8_t verbosity_level) {
                 const uint64_t act_next = nfs[i].stats.act_next;
                 const uint64_t act_buffer = nfs[i].stats.tx_buffer;
                 const uint64_t act_returned = nfs[i].stats.tx_returned;
+
+                /* On onvm_stats_clear_nf, subtraction causes underflow */
+                if (unlikely(rx == 0))
+                        nf_rx_last[i] = 0;
                 const uint64_t rx_pps = (rx - nf_rx_last[i]) / difftime;
+                if (unlikely(tx == 0))
+                        nf_tx_last[i] = 0;
                 const uint64_t tx_pps = (tx - nf_tx_last[i]) / difftime;
-                const uint64_t tx_drop_rate = (tx_drop - nf_tx_drop_last[i]) / difftime;
+                if (unlikely(rx_drop == 0))
+                        nf_rx_drop_last[i] = 0;
                 const uint64_t rx_drop_rate = (rx_drop - nf_rx_drop_last[i]) / difftime;
+                if (unlikely(tx_drop == 0))
+                        nf_tx_drop_last[i] = 0;
+                const uint64_t tx_drop_rate = (tx_drop - nf_tx_drop_last[i]) / difftime;
+
                 const uint64_t num_wakeups = nf_wakeup_infos[i].num_wakeups;
                 const uint64_t prev_num_wakeups = nf_wakeup_infos[i].prev_num_wakeups;
                 const uint64_t wakeup_rate = (num_wakeups - prev_num_wakeups) / difftime;
@@ -571,7 +582,6 @@ onvm_stats_display_nfs(unsigned difftime, uint8_t verbosity_level) {
                 fprintf(stats_out, "-----------------\n");
                 onvm_stats_display_client_wakeup_thread_context(difftime);
         }
-
 }
 
 /***************************Helper functions**********************************/

--- a/onvm/onvm_nflib/onvm_config_common.c
+++ b/onvm/onvm_nflib/onvm_config_common.c
@@ -39,10 +39,10 @@
  * to load an NF from a config file
  ********************************************************************/
 
+#include <rte_memcpy.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <rte_memcpy.h>
 
 #include "cJSON.h"
 #include "onvm_config_common.h"
@@ -406,21 +406,21 @@ onvm_config_create_onvm_args(cJSON* onvm_config, int* onvm_argc, char** onvm_arg
                 *onvm_argc += 2;
         }
 
-        *onvm_argv = (char**)malloc(sizeof(char*) * (*onvm_argc));
+        *onvm_argv = (char**)calloc(sizeof(char*) * (*onvm_argc), 1);
         if (*onvm_argv == NULL) {
                 printf("Unable to allocate space for onvm_argv\n");
                 return -1;
         }
 
         /* Allows for MAX_SERVICE_ID_SIZE number of characters in the number */
-        service_id_string = (char*)malloc(sizeof(char) * MAX_SERVICE_ID_SIZE);
+        service_id_string = (char*)calloc(sizeof(char) * MAX_SERVICE_ID_SIZE, 1);
         if (service_id_string == NULL) {
                 printf("Unable to allocate space for onvm_service_id_string\n");
                 free(*onvm_argv);
                 return -1;
         }
 
-        (*onvm_argv)[0] = malloc(sizeof(char) * strlen(FLAG_R));
+        (*onvm_argv)[0] = calloc(sizeof(char) * strlen(FLAG_R), 1);
         if ((*onvm_argv)[0] == NULL) {
                 printf("Unable to allocate space for onvm_argv[0]\n");
                 free(service_id_string);
@@ -434,7 +434,7 @@ onvm_config_create_onvm_args(cJSON* onvm_config, int* onvm_argc, char** onvm_arg
         (*onvm_argv)[1] = service_id_string;
 
         if (*onvm_argc > 2) {
-                instance_id_string = (char*)malloc(sizeof(char) * MAX_SERVICE_ID_SIZE);
+                instance_id_string = (char*)calloc(sizeof(char) * MAX_SERVICE_ID_SIZE, 1);
                 if (instance_id_string == NULL) {
                         printf("Unable to allocate space for onvm_instance_id_string\n");
                         free(service_id_string);
@@ -443,7 +443,7 @@ onvm_config_create_onvm_args(cJSON* onvm_config, int* onvm_argc, char** onvm_arg
                         return -1;
                 }
 
-                (*onvm_argv)[2] = malloc(sizeof(char) * strlen(FLAG_N));
+                (*onvm_argv)[2] = calloc(sizeof(char) * strlen(FLAG_N), 1);
                 if ((*onvm_argv)[2] == NULL) {
                         printf("Could not allocate space for instance id in argv\n");
                         free(instance_id_string);
@@ -491,7 +491,8 @@ onvm_config_create_dpdk_args(cJSON* dpdk_config, int* dpdk_argc, char** dpdk_arg
                 return -1;
         }
 
-        core_string = (char*)malloc(sizeof(char) * strlen(cJSON_GetObjectItem(dpdk_config, "corelist")->valuestring));
+        core_string =
+            (char*)malloc(sizeof(char) * strlen(cJSON_GetObjectItem(dpdk_config, "corelist")->valuestring) + 1);
         if (core_string == NULL) {
                 printf("Unable to allocate space for core string\n");
                 free(*dpdk_argv);
@@ -500,7 +501,7 @@ onvm_config_create_dpdk_args(cJSON* dpdk_config, int* dpdk_argc, char** dpdk_arg
         }
 
         core_string = strncpy(core_string, cJSON_GetObjectItem(dpdk_config, "corelist")->valuestring,
-                              strlen(cJSON_GetObjectItem(dpdk_config, "corelist")->valuestring));
+                              strlen(cJSON_GetObjectItem(dpdk_config, "corelist")->valuestring) + 1);
 
         if (onvm_config_extract_memory_channels(dpdk_config, &mem_channels) < 0) {
                 printf("Unable to extract memory channels\n");
@@ -522,15 +523,15 @@ onvm_config_create_dpdk_args(cJSON* dpdk_config, int* dpdk_argc, char** dpdk_arg
 
         snprintf(mem_channels_string, mem_channels_string_size, "%d", mem_channels);
 
-        arg_size[0] = strlen(FLAG_L);
-        arg_size[1] = strlen(core_string);
-        arg_size[2] = strlen(FLAG_N);
-        arg_size[3] = strlen(mem_channels_string);
-        arg_size[4] = strlen(PROC_TYPE_SECONDARY);
-        arg_size[5] = strlen(FLAG_DASH);
+        arg_size[0] = strlen(FLAG_L) + 1;
+        arg_size[1] = strlen(core_string) + 1;
+        arg_size[2] = strlen(FLAG_N) + 1;
+        arg_size[3] = strlen(mem_channels_string) + 1;
+        arg_size[4] = strlen(PROC_TYPE_SECONDARY) + 1;
+        arg_size[5] = strlen(FLAG_DASH) + 1;
 
         for (i = 0; i < *dpdk_argc; ++i) {
-                (*dpdk_argv)[i] = (char*)malloc(arg_size[i]);
+                (*dpdk_argv)[i] = (char*)calloc(arg_size[i], 1);
 
                 if ((*dpdk_argv)[i] == NULL) {
                         while (i != 0) {

--- a/onvm/onvm_nflib/onvm_config_common.c
+++ b/onvm/onvm_nflib/onvm_config_common.c
@@ -39,10 +39,10 @@
  * to load an NF from a config file
  ********************************************************************/
 
-#include <rte_memcpy.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <rte_memcpy.h>
 
 #include "cJSON.h"
 #include "onvm_config_common.h"

--- a/onvm/onvm_nflib/onvm_config_common.c
+++ b/onvm/onvm_nflib/onvm_config_common.c
@@ -49,6 +49,11 @@
 
 #define IS_NULL_OR_EMPTY_STRING(s) ((s) == NULL || strncmp(s, "", 1) == 0 ? 1 : 0)
 
+size_t
+strlenn(const char* __s) {
+        return strlen(__s) + 1;
+}
+
 cJSON*
 onvm_config_parse_file(const char* filename) {
         if (IS_NULL_OR_EMPTY_STRING(filename)) {
@@ -406,21 +411,21 @@ onvm_config_create_onvm_args(cJSON* onvm_config, int* onvm_argc, char** onvm_arg
                 *onvm_argc += 2;
         }
 
-        *onvm_argv = (char**)calloc(sizeof(char*) * (*onvm_argc), 1);
+        *onvm_argv = (char**)malloc(sizeof(char*) * (*onvm_argc));
         if (*onvm_argv == NULL) {
                 printf("Unable to allocate space for onvm_argv\n");
                 return -1;
         }
 
         /* Allows for MAX_SERVICE_ID_SIZE number of characters in the number */
-        service_id_string = (char*)calloc(sizeof(char) * MAX_SERVICE_ID_SIZE, 1);
+        service_id_string = (char*)malloc(sizeof(char) * MAX_SERVICE_ID_SIZE);
         if (service_id_string == NULL) {
                 printf("Unable to allocate space for onvm_service_id_string\n");
                 free(*onvm_argv);
                 return -1;
         }
 
-        (*onvm_argv)[0] = calloc(sizeof(char) * strlen(FLAG_R), 1);
+        (*onvm_argv)[0] = malloc(sizeof(char) * strlenn(FLAG_R));
         if ((*onvm_argv)[0] == NULL) {
                 printf("Unable to allocate space for onvm_argv[0]\n");
                 free(service_id_string);
@@ -428,13 +433,13 @@ onvm_config_create_onvm_args(cJSON* onvm_config, int* onvm_argc, char** onvm_arg
                 return -1;
         }
 
-        memcpy((*onvm_argv)[0], FLAG_R, strlen(FLAG_R));
+        memcpy((*onvm_argv)[0], FLAG_R, strlenn(FLAG_R));
 
         snprintf(service_id_string, sizeof(char) * MAX_SERVICE_ID_SIZE, "%d", service_id);
         (*onvm_argv)[1] = service_id_string;
 
         if (*onvm_argc > 2) {
-                instance_id_string = (char*)calloc(sizeof(char) * MAX_SERVICE_ID_SIZE, 1);
+                instance_id_string = (char*)malloc(sizeof(char) * MAX_SERVICE_ID_SIZE);
                 if (instance_id_string == NULL) {
                         printf("Unable to allocate space for onvm_instance_id_string\n");
                         free(service_id_string);
@@ -443,7 +448,7 @@ onvm_config_create_onvm_args(cJSON* onvm_config, int* onvm_argc, char** onvm_arg
                         return -1;
                 }
 
-                (*onvm_argv)[2] = calloc(sizeof(char) * strlen(FLAG_N), 1);
+                (*onvm_argv)[2] = malloc(sizeof(char) * strlenn(FLAG_N));
                 if ((*onvm_argv)[2] == NULL) {
                         printf("Could not allocate space for instance id in argv\n");
                         free(instance_id_string);
@@ -452,7 +457,7 @@ onvm_config_create_onvm_args(cJSON* onvm_config, int* onvm_argc, char** onvm_arg
                         free((*onvm_argv)[0]);
                         return -1;
                 }
-                memcpy((*onvm_argv)[2], FLAG_N, strlen(FLAG_N));
+                memcpy((*onvm_argv)[2], FLAG_N, strlenn(FLAG_N));
                 snprintf(instance_id_string, sizeof(char) * MAX_SERVICE_ID_SIZE, "%d", instance_id);
                 (*onvm_argv)[3] = instance_id_string;
         }
@@ -491,8 +496,7 @@ onvm_config_create_dpdk_args(cJSON* dpdk_config, int* dpdk_argc, char** dpdk_arg
                 return -1;
         }
 
-        core_string =
-            (char*)malloc(sizeof(char) * strlen(cJSON_GetObjectItem(dpdk_config, "corelist")->valuestring) + 1);
+        core_string = (char*)malloc(sizeof(char) * strlenn(cJSON_GetObjectItem(dpdk_config, "corelist")->valuestring));
         if (core_string == NULL) {
                 printf("Unable to allocate space for core string\n");
                 free(*dpdk_argv);
@@ -501,7 +505,7 @@ onvm_config_create_dpdk_args(cJSON* dpdk_config, int* dpdk_argc, char** dpdk_arg
         }
 
         core_string = strncpy(core_string, cJSON_GetObjectItem(dpdk_config, "corelist")->valuestring,
-                              strlen(cJSON_GetObjectItem(dpdk_config, "corelist")->valuestring) + 1);
+                              strlenn(cJSON_GetObjectItem(dpdk_config, "corelist")->valuestring));
 
         if (onvm_config_extract_memory_channels(dpdk_config, &mem_channels) < 0) {
                 printf("Unable to extract memory channels\n");
@@ -523,15 +527,15 @@ onvm_config_create_dpdk_args(cJSON* dpdk_config, int* dpdk_argc, char** dpdk_arg
 
         snprintf(mem_channels_string, mem_channels_string_size, "%d", mem_channels);
 
-        arg_size[0] = strlen(FLAG_L) + 1;
-        arg_size[1] = strlen(core_string) + 1;
-        arg_size[2] = strlen(FLAG_N) + 1;
-        arg_size[3] = strlen(mem_channels_string) + 1;
-        arg_size[4] = strlen(PROC_TYPE_SECONDARY) + 1;
-        arg_size[5] = strlen(FLAG_DASH) + 1;
+        arg_size[0] = strlenn(FLAG_L);
+        arg_size[1] = strlenn(core_string);
+        arg_size[2] = strlenn(FLAG_N);
+        arg_size[3] = strlenn(mem_channels_string);
+        arg_size[4] = strlenn(PROC_TYPE_SECONDARY);
+        arg_size[5] = strlenn(FLAG_DASH);
 
         for (i = 0; i < *dpdk_argc; ++i) {
-                (*dpdk_argv)[i] = (char*)calloc(arg_size[i], 1);
+                (*dpdk_argv)[i] = (char*)malloc(arg_size[i]);
 
                 if ((*dpdk_argv)[i] == NULL) {
                         while (i != 0) {

--- a/onvm/onvm_nflib/onvm_config_common.h
+++ b/onvm/onvm_nflib/onvm_config_common.h
@@ -55,6 +55,18 @@
 
 /*****************************API************************************/
 
+/*
+ * Uses strlen to get string length *including*
+ * null terminator '\0'
+ *
+ * @param __s
+ *   String to measure
+ * @return
+ *   Size of the string including null terminator
+ */
+size_t
+strlenn(const char* __s);
+
 /**
  * Parses a config file into a cJSON struct.
  * This struct contains all information stored within the config file

--- a/onvm/onvm_nflib/onvm_nflib.c
+++ b/onvm/onvm_nflib/onvm_nflib.c
@@ -146,8 +146,8 @@ onvm_nflib_parse_args(int argc, char *argv[], struct onvm_nf_init_cfg *nf_init_c
  * Check if there are packets in this NF's RX Queue and process them
  */
 static inline uint16_t
-onvm_nflib_dequeue_packets(void **pkts, struct onvm_nf_local_ctx *nf_local_ctx, nf_pkt_handler_fn handler)
-    __attribute__((always_inline));
+onvm_nflib_dequeue_packets(void **pkts, struct onvm_nf_local_ctx *nf_local_ctx,
+                           nf_pkt_handler_fn handler) __attribute__((always_inline));
 
 /*
  * Check if there is a message available for this NF and process it
@@ -236,7 +236,7 @@ struct onvm_nf_local_ctx *
 onvm_nflib_init_nf_local_ctx(void) {
         struct onvm_nf_local_ctx *nf_local_ctx;
 
-        nf_local_ctx = (struct onvm_nf_local_ctx *)calloc(1, sizeof(struct onvm_nf_local_ctx));
+        nf_local_ctx = (struct onvm_nf_local_ctx*)calloc(1, sizeof(struct onvm_nf_local_ctx));
         if (nf_local_ctx == NULL)
                 rte_exit(EXIT_FAILURE, "Failed to allocate memory for NF context\n");
 
@@ -254,7 +254,7 @@ struct onvm_nf_function_table *
 onvm_nflib_init_nf_function_table(void) {
         struct onvm_nf_function_table *nf_function_table;
 
-        nf_function_table = (struct onvm_nf_function_table *)calloc(1, sizeof(struct onvm_nf_function_table));
+        nf_function_table = (struct onvm_nf_function_table*)calloc(1, sizeof(struct onvm_nf_function_table));
         if (nf_function_table == NULL)
                 rte_exit(EXIT_FAILURE, "Failed to allocate memory for NF context\n");
 
@@ -266,9 +266,8 @@ onvm_nflib_request_lpm(struct lpm_request *lpm_req) {
         struct onvm_nf_msg *request_message;
         int ret;
 
-        ret = rte_mempool_get(nf_msg_pool, (void **)(&request_message));
-        if (ret != 0)
-                return ret;
+        ret = rte_mempool_get(nf_msg_pool, (void **) (&request_message));
+        if (ret != 0) return ret;
 
         request_message->msg_type = MSG_REQUEST_LPM_REGION;
         request_message->msg_data = lpm_req;
@@ -280,7 +279,7 @@ onvm_nflib_request_lpm(struct lpm_request *lpm_req) {
         }
 
         lpm_req->status = NF_WAITING_FOR_LPM;
-        for (; lpm_req->status == (uint16_t)NF_WAITING_FOR_LPM;) {
+        for (; lpm_req->status == (uint16_t) NF_WAITING_FOR_LPM;) {
                 sleep(1);
         }
 
@@ -294,12 +293,12 @@ onvm_nflib_request_ft(struct rte_hash_parameters *ipv4_hash_params) {
         struct ft_request *ft_req;
         int ret;
 
-        ft_req = (struct ft_request *)rte_malloc(NULL, sizeof(struct ft_request), 0);
+        ft_req = (struct ft_request *) rte_malloc(NULL, sizeof(struct ft_request), 0);
         if (!ft_req) {
                 return -1;
         }
 
-        ret = rte_mempool_get(nf_msg_pool, (void **)(&request_message));
+        ret = rte_mempool_get(nf_msg_pool, (void **) (&request_message));
         if (ret != 0) {
                 rte_mempool_put(nf_msg_pool, request_message);
                 return ret;
@@ -317,7 +316,7 @@ onvm_nflib_request_ft(struct rte_hash_parameters *ipv4_hash_params) {
         }
 
         ft_req->status = NF_WAITING_FOR_FT;
-        for (; ft_req->status == (uint16_t)NF_WAITING_FOR_FT;) {
+        for (; ft_req->status == (uint16_t) NF_WAITING_FOR_FT;) {
                 sleep(1);
         }
 
@@ -542,13 +541,12 @@ onvm_nflib_start_nf(struct onvm_nf_local_ctx *nf_local_ctx, struct onvm_nf_init_
                 RTE_LOG(INFO, APP, "Packet limit (rx) set to %u\n", nf->flags.pkt_limit);
 
         /*
-         * Allow this for cases when there is not enough cores and using
+         * Allow this for cases when there is not enough cores and using 
          * the shared core mode is not an option
          */
         if (ONVM_CHECK_BIT(nf->flags.init_options, SHARE_CORE_BIT) && !ONVM_NF_SHARE_CORES)
-                RTE_LOG(WARNING, APP,
-                        "Requested shared core allocation but shared core mode is NOT "
-                        "enabled, this will hurt performance, proceed with caution\n");
+               RTE_LOG(WARNING, APP, "Requested shared core allocation but shared core mode is NOT "
+                                     "enabled, this will hurt performance, proceed with caution\n");
 
         RTE_LOG(INFO, APP, "Finished Process Init.\n");
 
@@ -593,7 +591,7 @@ onvm_nflib_thread_main_loop(void *arg) {
                 nf->function_table->setup(nf_local_ctx);
 
         start_time = rte_get_tsc_cycles();
-        for (; rte_atomic16_read(&nf_local_ctx->keep_running) && rte_atomic16_read(&main_nf_local_ctx->keep_running);) {
+        for (;rte_atomic16_read(&nf_local_ctx->keep_running) && rte_atomic16_read(&main_nf_local_ctx->keep_running);) {
                 /* Possibly sleep if in shared core mode, otherwise continue */
                 if (ONVM_NF_SHARE_CORES) {
                         if (unlikely(rte_ring_count(nf->rx_q) == 0) && likely(rte_ring_count(nf->msg_q) == 0)) {
@@ -603,7 +601,7 @@ onvm_nflib_thread_main_loop(void *arg) {
                 }
 
                 nb_pkts_added =
-                    onvm_nflib_dequeue_packets((void **)pkts, nf_local_ctx, nf->function_table->pkt_handler);
+                        onvm_nflib_dequeue_packets((void **)pkts, nf_local_ctx, nf->function_table->pkt_handler);
 
                 if (likely(nb_pkts_added > 0)) {
                         onvm_pkt_process_tx_batch(nf->nf_tx_mgr, pkts, nb_pkts_added, nf);
@@ -617,17 +615,16 @@ onvm_nflib_thread_main_loop(void *arg) {
                 if (nf->function_table->user_actions != ONVM_NO_CALLBACK) {
                         rte_atomic16_set(&nf_local_ctx->keep_running,
                                          !(*nf->function_table->user_actions)(nf_local_ctx) &&
-                                             rte_atomic16_read(&nf_local_ctx->keep_running));
+                                         rte_atomic16_read(&nf_local_ctx->keep_running));
                 }
 
-                if (nf->flags.time_to_live &&
-                    unlikely((rte_get_tsc_cycles() - start_time) * TIME_TTL_MULTIPLIER / rte_get_timer_hz() >=
-                             nf->flags.time_to_live)) {
+                if (nf->flags.time_to_live && unlikely((rte_get_tsc_cycles() - start_time) *
+                                          TIME_TTL_MULTIPLIER / rte_get_timer_hz() >= nf->flags.time_to_live)) {
                         printf("Time to live exceeded, shutting down\n");
                         rte_atomic16_set(&nf_local_ctx->keep_running, 0);
                 }
-                if (nf->flags.pkt_limit &&
-                    unlikely(nf->stats.rx >= (uint64_t)nf->flags.pkt_limit * PKT_TTL_MULTIPLIER)) {
+                if (nf->flags.pkt_limit && unlikely(nf->stats.rx >= (uint64_t)nf->flags.pkt_limit *
+                                                                    PKT_TTL_MULTIPLIER)) {
                         printf("Packet limit exceeded, shutting down\n");
                         rte_atomic16_set(&nf_local_ctx->keep_running, 0);
                 }
@@ -693,7 +690,7 @@ onvm_nflib_handle_msg(struct onvm_nf_msg *msg, struct onvm_nf_local_ctx *nf_loca
                         break;
                 case MSG_SCALE:
                         RTE_LOG(INFO, APP, "Received scale message...\n");
-                        onvm_nflib_scale((struct onvm_nf_scale_info *)msg->msg_data);
+                        onvm_nflib_scale((struct onvm_nf_scale_info*)msg->msg_data);
                         break;
                 case MSG_FROM_NF:
                         RTE_LOG(INFO, APP, "Received MSG from other NF\n");
@@ -721,7 +718,7 @@ onvm_nflib_send_msg_to_nf(uint16_t dest, void *msg_data) {
         int ret;
         struct onvm_nf_msg *msg;
 
-        ret = rte_mempool_get(nf_msg_pool, (void **)(&msg));
+        ret = rte_mempool_get(nf_msg_pool, (void**)(&msg));
         if (ret != 0) {
                 RTE_LOG(INFO, APP, "Oh the huge manatee! Unable to allocate msg from pool :(\n");
                 return ret;
@@ -730,7 +727,7 @@ onvm_nflib_send_msg_to_nf(uint16_t dest, void *msg_data) {
         msg->msg_type = MSG_FROM_NF;
         msg->msg_data = msg_data;
 
-        return rte_ring_enqueue(nfs[dest].msg_q, (void *)msg);
+        return rte_ring_enqueue(nfs[dest].msg_q, (void*)msg);
 }
 
 void
@@ -961,7 +958,7 @@ onvm_nflib_parse_config(struct onvm_configuration *config) {
 }
 
 static inline uint16_t
-onvm_nflib_dequeue_packets(void **pkts, struct onvm_nf_local_ctx *nf_local_ctx, nf_pkt_handler_fn handler) {
+onvm_nflib_dequeue_packets(void **pkts, struct onvm_nf_local_ctx *nf_local_ctx, nf_pkt_handler_fn  handler) {
         struct onvm_nf *nf;
         struct onvm_pkt_meta *meta;
         uint16_t i, nb_pkts;
@@ -1094,6 +1091,7 @@ onvm_nflib_is_scale_info_valid(struct onvm_nf_scale_info *scale_info) {
                scale_info->function_table->pkt_handler != NULL;
 }
 
+
 static void
 onvm_nflib_nf_tx_mgr_init(struct onvm_nf *nf) {
         nf->nf_tx_mgr = rte_zmalloc(NULL, sizeof(struct queue_mgr), RTE_CACHE_LINE_SIZE);
@@ -1138,7 +1136,7 @@ onvm_nflib_parse_args(int argc, char *argv[], struct onvm_nf_init_cfg *nf_init_c
         int service_id = -1;
 
         opterr = 0;
-        while ((c = getopt(argc, argv, "r:n:t:l:ms")) != -1)
+        while ((c = getopt (argc, argv, "n:r:t:l:ms")) != -1)
                 switch (c) {
                         case 'n':
                                 initial_instance_id = (uint16_t)strtoul(optarg, NULL, 10);
@@ -1151,22 +1149,22 @@ onvm_nflib_parse_args(int argc, char *argv[], struct onvm_nf_init_cfg *nf_init_c
                                         service_id = -1;
                                 break;
                         case 't':
-                                nf_init_cfg->time_to_live = (uint16_t)strtoul(optarg, NULL, 10);
+                                nf_init_cfg->time_to_live = (uint16_t) strtoul(optarg, NULL, 10);
                                 if (nf_init_cfg->time_to_live == 0) {
                                         fprintf(stderr, "Time to live argument can't be 0\n");
                                         return -1;
                                 }
                                 break;
                         case 'l':
-                                nf_init_cfg->pkt_limit = (uint16_t)strtoul(optarg, NULL, 10);
+                                nf_init_cfg->pkt_limit = (uint16_t) strtoul(optarg, NULL, 10);
                                 if (nf_init_cfg->pkt_limit == 0) {
                                         fprintf(stderr, "Packet time to live argument can't be 0\n");
                                         return -1;
                                 }
                                 break;
                         case 'm':
-                                nf_init_cfg->init_options =
-                                    ONVM_SET_BIT(nf_init_cfg->init_options, MANUAL_CORE_ASSIGNMENT_BIT);
+                                nf_init_cfg->init_options = ONVM_SET_BIT(nf_init_cfg->init_options,
+                                                                         MANUAL_CORE_ASSIGNMENT_BIT);
                                 break;
                         case 's':
                                 nf_init_cfg->init_options = ONVM_SET_BIT(nf_init_cfg->init_options, SHARE_CORE_BIT);
@@ -1206,7 +1204,7 @@ onvm_nflib_terminate_children(struct onvm_nf *nf) {
                                 continue;
 
                         if (!onvm_nf_is_valid(&nfs[i]))
-                                continue;
+                               continue;
 
                         /* Wake up the child if its sleeping */
                         if (ONVM_NF_SHARE_CORES && rte_atomic16_read(nfs[i].shared_core.sleep_state) == 1) {
@@ -1214,8 +1212,8 @@ onvm_nflib_terminate_children(struct onvm_nf *nf) {
                                 sem_post(nfs[i].shared_core.nf_mutex);
                         }
                 }
-                RTE_LOG(INFO, APP, "NF %d: Waiting for %d children to exit\n", nf->instance_id,
-                        rte_atomic16_read(&nf->thread_info.children_cnt));
+                RTE_LOG(INFO, APP, "NF %d: Waiting for %d children to exit\n",
+                        nf->instance_id, rte_atomic16_read(&nf->thread_info.children_cnt));
                 sleep(NF_TERM_WAIT_TIME);
                 iter_cnt++;
         }
@@ -1312,7 +1310,7 @@ init_shared_core_mode_info(uint16_t instance_id) {
         if ((shmid = shmget(key, SHMSZ, 0666)) < 0)
                 rte_exit(EXIT_FAILURE, "Unable to locate the segment for NF %d\n", instance_id);
 
-        if ((shm = shmat(shmid, NULL, 0)) == (char *)-1)
+        if ((shm = shmat(shmid, NULL, 0)) == (char *) -1)
                 rte_exit(EXIT_FAILURE, "Can not attach the shared segment to the NF space for NF %d\n", instance_id);
 
         nf->shared_core.sleep_state = (rte_atomic16_t *)shm;
@@ -1323,10 +1321,9 @@ onvm_nflib_stats_summary_output(uint16_t id) {
         const char clr[] = {27, '[', '2', 'J', '\0'};
         const char topLeft[] = {27, '[', '1', ';', '1', 'H', '\0'};
         const char *csv_suffix = "_stats.csv";
-        const char *csv_stats_headers =
-            "NF tag, NF instance ID, NF service ID, NF assigned core, RX total,"
-            "RX total dropped, TX total, TX total dropped, NF sent out, NF sent to NF,"
-            "NF dropped, NF next, NF tx buffered, NF tx buffered, NF tx returned";
+        const char *csv_stats_headers = "NF tag, NF instance ID, NF service ID, NF assigned core, RX total,"
+                                        "RX total dropped, TX total, TX total dropped, NF sent out, NF sent to NF,"
+                                        "NF dropped, NF next, NF tx buffered, NF tx buffered, NF tx returned";
         const uint64_t rx = nfs[id].stats.rx;
         const uint64_t rx_drop = nfs[id].stats.rx_drop;
         const uint64_t tx = nfs[id].stats.tx;

--- a/onvm/onvm_nflib/onvm_nflib.c
+++ b/onvm/onvm_nflib/onvm_nflib.c
@@ -146,8 +146,8 @@ onvm_nflib_parse_args(int argc, char *argv[], struct onvm_nf_init_cfg *nf_init_c
  * Check if there are packets in this NF's RX Queue and process them
  */
 static inline uint16_t
-onvm_nflib_dequeue_packets(void **pkts, struct onvm_nf_local_ctx *nf_local_ctx,
-                           nf_pkt_handler_fn handler) __attribute__((always_inline));
+onvm_nflib_dequeue_packets(void **pkts, struct onvm_nf_local_ctx *nf_local_ctx, nf_pkt_handler_fn handler)
+    __attribute__((always_inline));
 
 /*
  * Check if there is a message available for this NF and process it
@@ -236,7 +236,7 @@ struct onvm_nf_local_ctx *
 onvm_nflib_init_nf_local_ctx(void) {
         struct onvm_nf_local_ctx *nf_local_ctx;
 
-        nf_local_ctx = (struct onvm_nf_local_ctx*)calloc(1, sizeof(struct onvm_nf_local_ctx));
+        nf_local_ctx = (struct onvm_nf_local_ctx *)calloc(1, sizeof(struct onvm_nf_local_ctx));
         if (nf_local_ctx == NULL)
                 rte_exit(EXIT_FAILURE, "Failed to allocate memory for NF context\n");
 
@@ -254,7 +254,7 @@ struct onvm_nf_function_table *
 onvm_nflib_init_nf_function_table(void) {
         struct onvm_nf_function_table *nf_function_table;
 
-        nf_function_table = (struct onvm_nf_function_table*)calloc(1, sizeof(struct onvm_nf_function_table));
+        nf_function_table = (struct onvm_nf_function_table *)calloc(1, sizeof(struct onvm_nf_function_table));
         if (nf_function_table == NULL)
                 rte_exit(EXIT_FAILURE, "Failed to allocate memory for NF context\n");
 
@@ -266,8 +266,9 @@ onvm_nflib_request_lpm(struct lpm_request *lpm_req) {
         struct onvm_nf_msg *request_message;
         int ret;
 
-        ret = rte_mempool_get(nf_msg_pool, (void **) (&request_message));
-        if (ret != 0) return ret;
+        ret = rte_mempool_get(nf_msg_pool, (void **)(&request_message));
+        if (ret != 0)
+                return ret;
 
         request_message->msg_type = MSG_REQUEST_LPM_REGION;
         request_message->msg_data = lpm_req;
@@ -279,7 +280,7 @@ onvm_nflib_request_lpm(struct lpm_request *lpm_req) {
         }
 
         lpm_req->status = NF_WAITING_FOR_LPM;
-        for (; lpm_req->status == (uint16_t) NF_WAITING_FOR_LPM;) {
+        for (; lpm_req->status == (uint16_t)NF_WAITING_FOR_LPM;) {
                 sleep(1);
         }
 
@@ -293,12 +294,12 @@ onvm_nflib_request_ft(struct rte_hash_parameters *ipv4_hash_params) {
         struct ft_request *ft_req;
         int ret;
 
-        ft_req = (struct ft_request *) rte_malloc(NULL, sizeof(struct ft_request), 0);
+        ft_req = (struct ft_request *)rte_malloc(NULL, sizeof(struct ft_request), 0);
         if (!ft_req) {
                 return -1;
         }
 
-        ret = rte_mempool_get(nf_msg_pool, (void **) (&request_message));
+        ret = rte_mempool_get(nf_msg_pool, (void **)(&request_message));
         if (ret != 0) {
                 rte_mempool_put(nf_msg_pool, request_message);
                 return ret;
@@ -316,7 +317,7 @@ onvm_nflib_request_ft(struct rte_hash_parameters *ipv4_hash_params) {
         }
 
         ft_req->status = NF_WAITING_FOR_FT;
-        for (; ft_req->status == (uint16_t) NF_WAITING_FOR_FT;) {
+        for (; ft_req->status == (uint16_t)NF_WAITING_FOR_FT;) {
                 sleep(1);
         }
 
@@ -541,12 +542,13 @@ onvm_nflib_start_nf(struct onvm_nf_local_ctx *nf_local_ctx, struct onvm_nf_init_
                 RTE_LOG(INFO, APP, "Packet limit (rx) set to %u\n", nf->flags.pkt_limit);
 
         /*
-         * Allow this for cases when there is not enough cores and using 
+         * Allow this for cases when there is not enough cores and using
          * the shared core mode is not an option
          */
         if (ONVM_CHECK_BIT(nf->flags.init_options, SHARE_CORE_BIT) && !ONVM_NF_SHARE_CORES)
-               RTE_LOG(WARNING, APP, "Requested shared core allocation but shared core mode is NOT "
-                                     "enabled, this will hurt performance, proceed with caution\n");
+                RTE_LOG(WARNING, APP,
+                        "Requested shared core allocation but shared core mode is NOT "
+                        "enabled, this will hurt performance, proceed with caution\n");
 
         RTE_LOG(INFO, APP, "Finished Process Init.\n");
 
@@ -591,7 +593,7 @@ onvm_nflib_thread_main_loop(void *arg) {
                 nf->function_table->setup(nf_local_ctx);
 
         start_time = rte_get_tsc_cycles();
-        for (;rte_atomic16_read(&nf_local_ctx->keep_running) && rte_atomic16_read(&main_nf_local_ctx->keep_running);) {
+        for (; rte_atomic16_read(&nf_local_ctx->keep_running) && rte_atomic16_read(&main_nf_local_ctx->keep_running);) {
                 /* Possibly sleep if in shared core mode, otherwise continue */
                 if (ONVM_NF_SHARE_CORES) {
                         if (unlikely(rte_ring_count(nf->rx_q) == 0) && likely(rte_ring_count(nf->msg_q) == 0)) {
@@ -601,7 +603,7 @@ onvm_nflib_thread_main_loop(void *arg) {
                 }
 
                 nb_pkts_added =
-                        onvm_nflib_dequeue_packets((void **)pkts, nf_local_ctx, nf->function_table->pkt_handler);
+                    onvm_nflib_dequeue_packets((void **)pkts, nf_local_ctx, nf->function_table->pkt_handler);
 
                 if (likely(nb_pkts_added > 0)) {
                         onvm_pkt_process_tx_batch(nf->nf_tx_mgr, pkts, nb_pkts_added, nf);
@@ -615,16 +617,17 @@ onvm_nflib_thread_main_loop(void *arg) {
                 if (nf->function_table->user_actions != ONVM_NO_CALLBACK) {
                         rte_atomic16_set(&nf_local_ctx->keep_running,
                                          !(*nf->function_table->user_actions)(nf_local_ctx) &&
-                                         rte_atomic16_read(&nf_local_ctx->keep_running));
+                                             rte_atomic16_read(&nf_local_ctx->keep_running));
                 }
 
-                if (nf->flags.time_to_live && unlikely((rte_get_tsc_cycles() - start_time) *
-                                          TIME_TTL_MULTIPLIER / rte_get_timer_hz() >= nf->flags.time_to_live)) {
+                if (nf->flags.time_to_live &&
+                    unlikely((rte_get_tsc_cycles() - start_time) * TIME_TTL_MULTIPLIER / rte_get_timer_hz() >=
+                             nf->flags.time_to_live)) {
                         printf("Time to live exceeded, shutting down\n");
                         rte_atomic16_set(&nf_local_ctx->keep_running, 0);
                 }
-                if (nf->flags.pkt_limit && unlikely(nf->stats.rx >= (uint64_t)nf->flags.pkt_limit *
-                                                                    PKT_TTL_MULTIPLIER)) {
+                if (nf->flags.pkt_limit &&
+                    unlikely(nf->stats.rx >= (uint64_t)nf->flags.pkt_limit * PKT_TTL_MULTIPLIER)) {
                         printf("Packet limit exceeded, shutting down\n");
                         rte_atomic16_set(&nf_local_ctx->keep_running, 0);
                 }
@@ -690,7 +693,7 @@ onvm_nflib_handle_msg(struct onvm_nf_msg *msg, struct onvm_nf_local_ctx *nf_loca
                         break;
                 case MSG_SCALE:
                         RTE_LOG(INFO, APP, "Received scale message...\n");
-                        onvm_nflib_scale((struct onvm_nf_scale_info*)msg->msg_data);
+                        onvm_nflib_scale((struct onvm_nf_scale_info *)msg->msg_data);
                         break;
                 case MSG_FROM_NF:
                         RTE_LOG(INFO, APP, "Received MSG from other NF\n");
@@ -718,7 +721,7 @@ onvm_nflib_send_msg_to_nf(uint16_t dest, void *msg_data) {
         int ret;
         struct onvm_nf_msg *msg;
 
-        ret = rte_mempool_get(nf_msg_pool, (void**)(&msg));
+        ret = rte_mempool_get(nf_msg_pool, (void **)(&msg));
         if (ret != 0) {
                 RTE_LOG(INFO, APP, "Oh the huge manatee! Unable to allocate msg from pool :(\n");
                 return ret;
@@ -727,7 +730,7 @@ onvm_nflib_send_msg_to_nf(uint16_t dest, void *msg_data) {
         msg->msg_type = MSG_FROM_NF;
         msg->msg_data = msg_data;
 
-        return rte_ring_enqueue(nfs[dest].msg_q, (void*)msg);
+        return rte_ring_enqueue(nfs[dest].msg_q, (void *)msg);
 }
 
 void
@@ -958,7 +961,7 @@ onvm_nflib_parse_config(struct onvm_configuration *config) {
 }
 
 static inline uint16_t
-onvm_nflib_dequeue_packets(void **pkts, struct onvm_nf_local_ctx *nf_local_ctx, nf_pkt_handler_fn  handler) {
+onvm_nflib_dequeue_packets(void **pkts, struct onvm_nf_local_ctx *nf_local_ctx, nf_pkt_handler_fn handler) {
         struct onvm_nf *nf;
         struct onvm_pkt_meta *meta;
         uint16_t i, nb_pkts;
@@ -1091,7 +1094,6 @@ onvm_nflib_is_scale_info_valid(struct onvm_nf_scale_info *scale_info) {
                scale_info->function_table->pkt_handler != NULL;
 }
 
-
 static void
 onvm_nflib_nf_tx_mgr_init(struct onvm_nf *nf) {
         nf->nf_tx_mgr = rte_zmalloc(NULL, sizeof(struct queue_mgr), RTE_CACHE_LINE_SIZE);
@@ -1136,7 +1138,7 @@ onvm_nflib_parse_args(int argc, char *argv[], struct onvm_nf_init_cfg *nf_init_c
         int service_id = -1;
 
         opterr = 0;
-        while ((c = getopt (argc, argv, "n:r:t:l:ms")) != -1)
+        while ((c = getopt(argc, argv, "r:n:t:l:ms")) != -1)
                 switch (c) {
                         case 'n':
                                 initial_instance_id = (uint16_t)strtoul(optarg, NULL, 10);
@@ -1149,22 +1151,22 @@ onvm_nflib_parse_args(int argc, char *argv[], struct onvm_nf_init_cfg *nf_init_c
                                         service_id = -1;
                                 break;
                         case 't':
-                                nf_init_cfg->time_to_live = (uint16_t) strtoul(optarg, NULL, 10);
+                                nf_init_cfg->time_to_live = (uint16_t)strtoul(optarg, NULL, 10);
                                 if (nf_init_cfg->time_to_live == 0) {
                                         fprintf(stderr, "Time to live argument can't be 0\n");
                                         return -1;
                                 }
                                 break;
                         case 'l':
-                                nf_init_cfg->pkt_limit = (uint16_t) strtoul(optarg, NULL, 10);
+                                nf_init_cfg->pkt_limit = (uint16_t)strtoul(optarg, NULL, 10);
                                 if (nf_init_cfg->pkt_limit == 0) {
                                         fprintf(stderr, "Packet time to live argument can't be 0\n");
                                         return -1;
                                 }
                                 break;
                         case 'm':
-                                nf_init_cfg->init_options = ONVM_SET_BIT(nf_init_cfg->init_options,
-                                                                         MANUAL_CORE_ASSIGNMENT_BIT);
+                                nf_init_cfg->init_options =
+                                    ONVM_SET_BIT(nf_init_cfg->init_options, MANUAL_CORE_ASSIGNMENT_BIT);
                                 break;
                         case 's':
                                 nf_init_cfg->init_options = ONVM_SET_BIT(nf_init_cfg->init_options, SHARE_CORE_BIT);
@@ -1204,7 +1206,7 @@ onvm_nflib_terminate_children(struct onvm_nf *nf) {
                                 continue;
 
                         if (!onvm_nf_is_valid(&nfs[i]))
-                               continue;
+                                continue;
 
                         /* Wake up the child if its sleeping */
                         if (ONVM_NF_SHARE_CORES && rte_atomic16_read(nfs[i].shared_core.sleep_state) == 1) {
@@ -1212,8 +1214,8 @@ onvm_nflib_terminate_children(struct onvm_nf *nf) {
                                 sem_post(nfs[i].shared_core.nf_mutex);
                         }
                 }
-                RTE_LOG(INFO, APP, "NF %d: Waiting for %d children to exit\n",
-                        nf->instance_id, rte_atomic16_read(&nf->thread_info.children_cnt));
+                RTE_LOG(INFO, APP, "NF %d: Waiting for %d children to exit\n", nf->instance_id,
+                        rte_atomic16_read(&nf->thread_info.children_cnt));
                 sleep(NF_TERM_WAIT_TIME);
                 iter_cnt++;
         }
@@ -1310,7 +1312,7 @@ init_shared_core_mode_info(uint16_t instance_id) {
         if ((shmid = shmget(key, SHMSZ, 0666)) < 0)
                 rte_exit(EXIT_FAILURE, "Unable to locate the segment for NF %d\n", instance_id);
 
-        if ((shm = shmat(shmid, NULL, 0)) == (char *) -1)
+        if ((shm = shmat(shmid, NULL, 0)) == (char *)-1)
                 rte_exit(EXIT_FAILURE, "Can not attach the shared segment to the NF space for NF %d\n", instance_id);
 
         nf->shared_core.sleep_state = (rte_atomic16_t *)shm;
@@ -1321,9 +1323,10 @@ onvm_nflib_stats_summary_output(uint16_t id) {
         const char clr[] = {27, '[', '2', 'J', '\0'};
         const char topLeft[] = {27, '[', '1', ';', '1', 'H', '\0'};
         const char *csv_suffix = "_stats.csv";
-        const char *csv_stats_headers = "NF tag, NF instance ID, NF service ID, NF assigned core, RX total,"
-                                        "RX total dropped, TX total, TX total dropped, NF sent out, NF sent to NF,"
-                                        "NF dropped, NF next, NF tx buffered, NF tx buffered, NF tx returned";
+        const char *csv_stats_headers =
+            "NF tag, NF instance ID, NF service ID, NF assigned core, RX total,"
+            "RX total dropped, TX total, TX total dropped, NF sent out, NF sent to NF,"
+            "NF dropped, NF next, NF tx buffered, NF tx buffered, NF tx returned";
         const uint64_t rx = nfs[id].stats.rx;
         const uint64_t rx_drop = nfs[id].stats.rx_drop;
         const uint64_t tx = nfs[id].stats.tx;


### PR DESCRIPTION
Users can now re-launch NFs with the same instance ID, and memory bugs were fixed allowing JSON configs to work again.


<!-- Add detailed description and provide running instructions -->
## Summary:
This PR fixes 2 bugs that were referenced heavily in Slack and in a different issue (#233). I made a `strlenn` function which is an adaptation on `string.h`'s `strlen` std library function. Normally, `strlen` does not include the null terminator when calculating the length of the string. This is a memory leak problem for our situation because we `memcpy` the string and need the '\0' to denote when to stop reading the config.

The second issue was the re-launch of instance IDs. This required a ring cleanup, but also on the stats side in `onvm_stats.c`, we needed to update `nf_rx_last` (a static function variable) after cleaning up the rx stats on the `nfs` table. This part is probably messy with the `unlikely`, but it's purpose is to avoid `underflow` with subtracting unsigned integers.

**Usage:**

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | #233 
| Breaking API changes     |
| Internal API changes     | 
| Usability improvements   |  
| Bug fixes                | 👍 
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [ ] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:
If you notice with the current version of develop, running (with the bridge NF) `./go.sh -F ../example_config.json` does not work. Also, if you try to run `speed_tester` for example twice with the same instance ID
(`./go.sh -l 5 -- -m -r 3 -n 2 -- 3 -d 3`), there will be an `rte_exit` from the manager because the rings weren't freed. Those are the two main tests to run and see that they are now fixed.

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
@twood02 

(optional) **Subscribers:** << @-mention people who probably care about these changes >>
anyone else (maybe @catherinemeadows because you made the previous issue report)