### PR TITLE
Add support for jumbo frames

### DIFF
--- a/onvm/go.sh
+++ b/onvm/go.sh
@@ -16,6 +16,8 @@ function usage {
         echo -e "\tRuns ONVM the same way as above, but prints statistics to stdout"
         echo -e "$0 -k 3 -n 0xF0 -m 2,3,4 -s stdout -c"
         echo -e "\tRuns ONVM the same way as above, but enables shared cpu support"
+        echo -e "$0 -k 3 -n 0xF0 -m 2,3,4 -s stdout -c -j"
+        echo -e "\tRuns ONVM the same way as above, but allows ports to send and receive jumbo frames"
         echo -e "$0 -k 3 -n 0xF0 -m 2,3,4 -s stdout -t 42"
         echo -e "\tRuns ONVM the same way as above, but shuts down after 42 seconds"
         echo -e "$0 -k 3 -n 0xF0 -m 2,3,4 -s stdout -l 64"
@@ -110,7 +112,7 @@ then
     exit 1
 fi
 
-while getopts "a:r:d:s:t:l:p:z:cvm:k:n:" opt; do
+while getopts "a:r:d:s:t:l:p:z:cvm:k:n:j" opt; do
     case $opt in
         a) virt_addr="--base-virtaddr=$OPTARG";;
         r) num_srvc="-r $OPTARG";;
@@ -152,6 +154,7 @@ while getopts "a:r:d:s:t:l:p:z:cvm:k:n:" opt; do
             else
                 nf_cores=$OPTARG
             fi;;
+        j) jumbo_frames_flag="-j";;
         \?) echo "Unknown option -$OPTARG" && usage
             ;;
     esac
@@ -269,7 +272,7 @@ fi
 sudo rm -rf /mnt/huge/rtemap_*
 # watch out for variable expansion
 # shellcheck disable=SC2086
-sudo "$SCRIPTPATH"/onvm_mgr/"$RTE_TARGET"/onvm_mgr -l "$cpu" -n 4 --proc-type=primary ${virt_addr} -- -p ${ports} -n ${nf_cores} ${num_srvc} ${def_srvc} ${stats} ${stats_sleep_time} ${verbosity_level} ${ttl} ${packet_limit} ${shared_cpu_flag}
+sudo "$SCRIPTPATH"/onvm_mgr/"$RTE_TARGET"/onvm_mgr -l "$cpu" -n 4 --proc-type=primary ${virt_addr} -- -p ${ports} -n ${nf_cores} ${num_srvc} ${def_srvc} ${stats} ${stats_sleep_time} ${verbosity_level} ${ttl} ${packet_limit} ${shared_cpu_flag} ${jumbo_frames_flag}
 
 if [ "${stats}" = "-s web" ]
 then

--- a/onvm/onvm_mgr/onvm_args.c
+++ b/onvm/onvm_mgr/onvm_args.c
@@ -79,6 +79,9 @@ uint8_t global_verbosity_level = 1;
 /* global flag for enabling shared core logic - extern in init.h */
 uint8_t ONVM_NF_SHARE_CORES = 0;
 
+/* global flag for jumbo frames - extern in init.h */
+uint8_t ONVM_USE_JUMBO_FRAMES = 0;
+
 /* global var for program name */
 static const char *progname;
 
@@ -126,11 +129,12 @@ parse_app_args(uint8_t max_ports, int argc, char *argv[]) {
             {"nf-cores", required_argument, NULL, 'n'},  {"default-service", required_argument, NULL, 'd'},
             {"stats-out", no_argument, NULL, 's'},       {"stats-sleep-time", no_argument, NULL, 'z'},
             {"time_to_live", no_argument, NULL, 't'},    {"packet_limit", no_argument, NULL, 'l'},
-            {"verbocity-level", no_argument, NULL, 'v'}, {"enable_shared_cpu", no_argument, NULL, 'c'}};
+            {"verbocity-level", no_argument, NULL, 'v'}, {"enable_shared_cpu", no_argument, NULL, 'c'},
+            {"jumbo_frames", no_argument, NULL, 'j'}};
 
         progname = argv[0];
 
-        while ((opt = getopt_long(argc, argvopt, "p:r:n:d:s:t:l:z:v:c", lgopts, &option_index)) != EOF) {
+        while ((opt = getopt_long(argc, argvopt, "p:r:n:d:s:t:l:z:v:cj", lgopts, &option_index)) != EOF) {
                 switch (opt) {
                         case 'p':
                                 if (parse_portmask(max_ports, optarg) != 0) {
@@ -192,6 +196,9 @@ parse_app_args(uint8_t max_ports, int argc, char *argv[]) {
                                 onvm_config->flags.ONVM_NF_SHARE_CORES = 1;
                                 ONVM_NF_SHARE_CORES = 1;
                                 break;
+                        case 'j':
+                                ONVM_USE_JUMBO_FRAMES = 1;
+                                break;
                         default:
                                 printf("ERROR: Unknown option '%c'\n", opt);
                                 usage();
@@ -216,7 +223,8 @@ usage(void) {
             "\t-t TTL: time to live, how many seconds to wait until exiting (optional)\n"
             "\t-l PACKET_LIMIT: how many millions of packets to recieve before exiting (optional)\n"
             "\t-v VERBOCITY_LEVEL: verbocity level of the stats output (optional)\n"
-            "\t-c ENABLE_SHARED_CORE: allow the NFs to share a core based on mutex sleep/wakeups (optional)\n",
+            "\t-c ENABLE_SHARED_CORE: allow the NFs to share a core based on mutex sleep/wakeups (optional)\n"
+            "\t-j JUMBO_FRAMES: allow the ports to send and receive jumbo frames (optional)\n",
             progname);
 }
 

--- a/onvm/onvm_mgr/onvm_init.h
+++ b/onvm/onvm_mgr/onvm_init.h
@@ -79,8 +79,6 @@
 
 #define MBUF_CACHE_SIZE 512
 #define MBUF_OVERHEAD (sizeof(struct rte_mbuf) + RTE_PKTMBUF_HEADROOM)
-#define RX_MBUF_DATA_SIZE 2048
-#define MBUF_SIZE (RX_MBUF_DATA_SIZE + MBUF_OVERHEAD)
 
 #define NF_INFO_SIZE sizeof(struct onvm_nf_init_cfg)
 
@@ -126,6 +124,7 @@ extern uint8_t global_verbosity_level;
 /* Custom flags for onvm */
 extern struct onvm_configuration *onvm_config;
 extern uint8_t ONVM_NF_SHARE_CORES;
+extern uint8_t ONVM_USE_JUMBO_FRAMES;
 
 /* For handling shared core logic */
 extern struct nf_wakeup_info *nf_wakeup_infos;


### PR DESCRIPTION
Support for Jumbo Frames.

<!-- Hey, thanks for contributing to openNetVM! When submitting your Pull Request, please make sure you're submitting to the sdnfv:develop branch. Once we have a good set of merged PR's on develop, we'll merge everything to sdnfv:master for a release. -->

This PR adds support for the manager to receive jumbo frames with Ethernet payload upto 9600 bytes. It also ensures that there is enough memory allocated by the manager to process the same number of packets as before. This enhancement is made optional and can be enabled by using a flag (mentioned below) when executing the _go.sh_ script.

<!-- Add detailed description and provide running instructions -->
## Summary:

**Usage:**
New flag: `-j` Allow ports to send and receive jumbo frames

<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | <!-- Provide a list of issues --> 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   |
| Bug fixes                |
| New functionality        |
| New NF/onvm_mgr args     | Yes
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [ ] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:

The PR was tested using the following setup:

### Topology

Node1--------Node2--------Node3

OpenNetVM was run on Node2 along with the l2fwd example NF.

### Commands:

The manager was run using the following command:

`./go.sh -k 3 -n 0xF8 -m 0,1,2 -s stdout -j`

The l2fwd NF was run using the following command:

`./go.sh 1 -n`

The MTU on the interfaces of Node1 and Node2 was set to 9000 bytes using the following command:

`# ip link set <interface_name> mtu 9000`

The support for jumbo frames was tested by running a ping test from Node1 to Node3 using the following command on Node1:

`$ ping <ip_address> -M do -s 8972`

Correct working was verified by obtaining a successful ping and observing the packets being processed in the manager and NF.

pktgen-dpdk was also employed to test these changes. pktgen-dpdk was run on Node1 and Node3, and the size of the frames in the traffic was set to 9618 bytes.

Command used to run pktgen-dpdk:

`# ./pktgen -l 0-2 -n 2 -- -T -P -j -m "[1:2].0"`

pktgen cli command to set frame size:

`Pktgen:/> set 0 size 9618`

--- Update ---

_Updated description_
_Added pktgen-dpdk test plan_

<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
**Subscribers:** @twood02 @kkrama 
