### PR TITLE
Prints out socket that is in use whenever core is also printed out. Also outputs socket ID to CSV.

### DIFF
--- a/onvm/onvm_nflib/onvm_nflib.c
+++ b/onvm/onvm_nflib/onvm_nflib.c
@@ -533,7 +533,7 @@ onvm_nflib_start_nf(struct onvm_nf_local_ctx *nf_local_ctx, struct onvm_nf_init_
 
         RTE_LOG(INFO, APP, "Using Instance ID %d\n", nf->instance_id);
         RTE_LOG(INFO, APP, "Using Service ID %d\n", nf->service_id);
-        RTE_LOG(INFO, APP, "Running on core %d\n", nf->thread_info.core);
+        RTE_LOG(INFO, APP, "Running on Socket %d, Core %d\n", rte_socket_id(), nf->thread_info.core);
 
         if (nf->flags.time_to_live)
                 RTE_LOG(INFO, APP, "Time to live set to %u\n", nf->flags.time_to_live);
@@ -1321,7 +1321,7 @@ onvm_nflib_stats_summary_output(uint16_t id) {
         const char clr[] = {27, '[', '2', 'J', '\0'};
         const char topLeft[] = {27, '[', '1', ';', '1', 'H', '\0'};
         const char *csv_suffix = "_stats.csv";
-        const char *csv_stats_headers = "NF tag, NF instance ID, NF service ID, NF assigned core, RX total,"
+        const char *csv_stats_headers = "NF tag, NF instance ID, NF service ID, NF assigned socket, NF assigned core, RX total,"
                                         "RX total dropped, TX total, TX total dropped, NF sent out, NF sent to NF,"
                                         "NF dropped, NF next, NF tx buffered, NF tx buffered, NF tx returned";
         const uint64_t rx = nfs[id].stats.rx;
@@ -1348,6 +1348,7 @@ onvm_nflib_stats_summary_output(uint16_t id) {
         printf("NF tag: %s\n", nf_tag);
         printf("NF instance ID: %d\n", instance_id);
         printf("NF service ID: %d\n", service_id);
+        printf("NF assigned socket: %d\n", rte_socket_id());
         printf("NF assigned core: %d\n", core);
         printf("----------------------------------------------------\n");
         printf("RX total: %ld\n", rx);
@@ -1390,6 +1391,7 @@ onvm_nflib_stats_summary_output(uint16_t id) {
         fprintf(csv_fp, "\n%s", nf_tag);
         fprintf(csv_fp, ", %d", instance_id);
         fprintf(csv_fp, ", %d", service_id);
+        fprintf(csv_fp, ", %d", rte_socket_id());
         fprintf(csv_fp, ", %d", core);
         fprintf(csv_fp, ", %ld", rx);
         fprintf(csv_fp, ", %ld", rx_drop);


### PR DESCRIPTION
## Summary:
This PR changes two files, `main.c` in `onvm_mgr` and `onvm_nflib.c` in `onvm_nflib`. All `printf` statements that had core information in them were added to include the socket information as well. It also adds the information to the CVS files that output at the end of execution.
**Usage:**
There is nothing that needs to be done to have this work other than `make clean && make` in `onvm` and `examples`.
<!-- Check list of the things this PR accomplishes -->
| This PR includes         |          |
| ------------------------ | -------- |
| Resolves issues          | 
| Breaking API changes     |
| Internal API changes     |
| Usability improvements   | x | 
| Bug fixes                |
| New functionality        |
| New NF/onvm_mgr args     | 
| Changes to starting NFs  |  
| Dependency updates       | 
| Web stats updates        | 


<!-- If the pr has any dependencies or merge quirks note them here -->
## Merging notes:
 - Dependencies: None  

**TODO before merging :**
 - [x] PR is ready for review


<!-- What you did to test the PR, what needs to be done -->
## Test Plan:
Tested by running the manager and various NFs to make sure the socket information was output correctly.
<!-- Notes about what you think should be reviewed, any specific hacks in this PR -->
## Review: 
@twood02 
@dennisafa 
