### PR TITLE
simple_forward: Validate destination argument (-d)

### DIFF
--- a/examples/simple_forward/forward.c
+++ b/examples/simple_forward/forward.c
@@ -85,10 +85,19 @@ parse_app_args(int argc, char *argv[], const char *progname) {
 
         while ((c = getopt(argc, argv, "d:p:")) != -1) {
                 switch (c) {
-                        case 'd':
-                                destination = strtoul(optarg, NULL, 10);
+                        case 'd': {
+                                char *end = NULL;
+                                unsigned long val = strtoul(optarg, &end, 10);
+
+                                if (end == optarg || *end != '\0') {
+                                        RTE_LOG(INFO, APP, "Invalid destination ID: %s\n", optarg);
+                                        return -1;
+                                }
+
+                                destination = (uint32_t)val;
                                 dst_flag = 1;
                                 break;
+                        }
                         case 'p':
                                 print_delay = strtoul(optarg, NULL, 10);
                                 break;


### PR DESCRIPTION
## Problem
Previously, the -d argument was parsed without validating the input.
This could lead to unintended behavior when non-numeric values were
provided, silently defaulting to 0.

## Solution
Added validation to ensure only valid numeric service IDs are accepted.

## Test Plan
- Ran NF with valid -d values (e.g., 1, 2) → works correctly
- Ran NF with invalid values (e.g., abc, 1abc) → error handled